### PR TITLE
Add Cognito User Pools clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 This set of extensions allows you to interact with some of the AWS Services namely:
 
+ * Cognito User Pools
  * DynamoDB
  * IAM
  * KMS

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -122,6 +122,16 @@
                 <artifactId>quarkus-amazon-ssm-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-cognito-user-pools-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/cognito-user-pools/deployment/pom.xml
+++ b/cognito-user-pools/deployment/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-cognito-user-pools-parent</artifactId>
+        <version>1.0.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-cognito-user-pools-deployment</artifactId>
+    <name>Quarkus - Amazon Services - Cognito User Pools - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
+++ b/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
@@ -1,0 +1,149 @@
+package io.quarkus.amazon.cognitouserpools.deployment;
+
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.amazon.cognitouserpools.runtime.CognitoUserPoolsBuildTimeConfig;
+import io.quarkus.amazon.cognitouserpools.runtime.CognitoUserPoolsClientProducer;
+import io.quarkus.amazon.cognitouserpools.runtime.CognitoUserPoolsRecorder;
+import io.quarkus.amazon.common.deployment.AbstractAmazonServiceProcessor;
+import io.quarkus.amazon.common.deployment.AmazonClientAsyncTransportBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientInterceptorsPathBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonClientSyncTransportBuildItem;
+import io.quarkus.amazon.common.deployment.AmazonHttpClients;
+import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClientBuilder;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClientBuilder;
+
+public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
+
+    private static final String AMAZON_COGNITO_USER_POOLS = "amazon-cognito-user-pools";
+
+    CognitoUserPoolsBuildTimeConfig buildTimeConfig;
+
+    @Override
+    protected String amazonServiceClientName() {
+        return AMAZON_COGNITO_USER_POOLS;
+    }
+
+    @Override
+    protected String configName() {
+        return "cognito-user-pools";
+    }
+
+    @Override
+    protected DotName syncClientName() {
+        return DotName.createSimple(CognitoIdentityProviderClient.class.getName());
+    }
+
+    @Override
+    protected DotName asyncClientName() {
+        return DotName.createSimple(CognitoIdentityProviderAsyncClient.class.getName());
+    }
+
+    @Override
+    protected String builtinInterceptorsPath() {
+        return "software/amazon/awssdk/services/cognitoidentityprovider/execution.interceptors";
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem producer() {
+        return AdditionalBeanBuildItem.unremovableOf(CognitoUserPoolsClientProducer.class);
+    }
+
+    @BuildStep
+    void setup(BeanRegistrationPhaseBuildItem beanRegistrationPhase,
+            BuildProducer<ExtensionSslNativeSupportBuildItem> extensionSslNativeSupport,
+            BuildProducer<FeatureBuildItem> feature,
+            BuildProducer<AmazonClientInterceptorsPathBuildItem> interceptors,
+            BuildProducer<AmazonClientBuildItem> clientProducer) {
+
+        setupExtension(beanRegistrationPhase,
+                extensionSslNativeSupport,
+                feature,
+                interceptors,
+                clientProducer,
+                buildTimeConfig.sdk,
+                buildTimeConfig.syncClient);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonApacheHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupApacheSyncTransport(List<AmazonClientBuildItem> amazonClients,
+            CognitoUserPoolsRecorder recorder,
+            AmazonClientApacheTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createApacheSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient,
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients,
+            CognitoUserPoolsRecorder recorder,
+            AmazonClientUrlConnectionTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createUrlConnectionSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient,
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonNettyHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupNettyAsyncTransport(List<AmazonClientBuildItem> amazonClients,
+            CognitoUserPoolsRecorder recorder,
+            AmazonClientNettyTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports) {
+
+        createNettyAsyncTransportBuilder(amazonClients,
+                transportRecorder,
+                recorder.getAsyncConfig(),
+                asyncTransports);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void createClientBuilders(CognitoUserPoolsRecorder recorder,
+            AmazonClientRecorder commonRecorder,
+            List<AmazonClientSyncTransportBuildItem> syncTransports,
+            List<AmazonClientAsyncTransportBuildItem> asyncTransports,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+
+        createClientBuilders(commonRecorder,
+                recorder.getAwsConfig(),
+                recorder.getSdkConfig(),
+                buildTimeConfig.sdk,
+                syncTransports,
+                asyncTransports,
+                CognitoIdentityProviderClientBuilder.class,
+                (syncTransport) -> recorder.createSyncBuilder(syncTransport),
+                CognitoIdentityProviderAsyncClientBuilder.class,
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                null,
+                null,
+                syntheticBeans);
+    }
+}

--- a/cognito-user-pools/deployment/src/test/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsBrokenEndpointConfigTest.java
+++ b/cognito-user-pools/deployment/src/test/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsBrokenEndpointConfigTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.amazon.cognitouserpools.deployment;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.amazon.common.runtime.RuntimeConfigurationError;
+import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+public class CognitoUserPoolsBrokenEndpointConfigTest {
+
+    @Inject
+    CognitoIdentityProviderClient sync;
+
+    @Inject
+    CognitoIdentityProviderAsyncClient async;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setExpectedException(RuntimeConfigurationError.class)
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("broken-endpoint-config.properties", "application.properties"));
+
+    @Test
+    public void test() {
+        // should not be called, deployment exception should happen first.
+        Assertions.fail();
+    }
+}

--- a/cognito-user-pools/deployment/src/test/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsSyncClientFullConfigTest.java
+++ b/cognito-user-pools/deployment/src/test/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsSyncClientFullConfigTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.amazon.cognitouserpools.deployment;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+public class CognitoUserPoolsSyncClientFullConfigTest {
+
+    @Inject
+    CognitoIdentityProviderClient client;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("full-config.properties", "application.properties"));
+
+    @Test
+    public void test() {
+        // should finish with success
+    }
+}

--- a/cognito-user-pools/deployment/src/test/resources/broken-endpoint-config.properties
+++ b/cognito-user-pools/deployment/src/test/resources/broken-endpoint-config.properties
@@ -1,0 +1,4 @@
+quarkus.cognito-user-pools.aws.region=us-east-1
+
+quarkus.cognito-user-pools.endpoint-override=127.0.0.1
+

--- a/cognito-user-pools/deployment/src/test/resources/full-config.properties
+++ b/cognito-user-pools/deployment/src/test/resources/full-config.properties
@@ -1,0 +1,10 @@
+quarkus.cognito-user-pools.endpoint-override=http://localhost:9090
+
+quarkus.cognito-user-pools.aws.region=us-east-2
+quarkus.cognito-user-pools.aws.credentials.type=static
+quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id=test-key
+quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key=test-secret
+
+quarkus.cognito-user-pools.sync-client.type = url
+quarkus.cognito-user-pools.sync-client.connection-timeout = 0.100S
+quarkus.cognito-user-pools.sync-client.socket-timeout = 0.100S

--- a/cognito-user-pools/pom.xml
+++ b/cognito-user-pools/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-services-build-parent</artifactId>
+        <version>1.0.6-SNAPSHOT</version>
+        <relativePath>../build-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-cognito-user-pools-parent</artifactId>
+    <name>Quarkus - Amazon Services - Cognito User Pools</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/cognito-user-pools/runtime/pom.xml
+++ b/cognito-user-pools/runtime/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-cognito-user-pools-parent</artifactId>
+        <version>1.0.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
+    <name>Quarkus - Amazon Services - Cognito User Pools - Runtime</name>
+    <description>Connect to Amazon Cognito User Pools service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cognitoidentityprovider</artifactId>
+            <exclusions>
+                <!-- we exclude them here because we want to make them optional -->
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>url-connection-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsBuildTimeConfig.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsBuildTimeConfig.java
@@ -1,0 +1,26 @@
+package io.quarkus.amazon.cognitouserpools.runtime;
+
+import io.quarkus.amazon.common.runtime.SdkBuildTimeConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientBuildTimeConfig;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Amazon Cognito Identity Provider (User Pools) build time configuration
+ */
+@ConfigRoot(name = "cognito-user-pools", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class CognitoUserPoolsBuildTimeConfig {
+
+    /**
+     * SDK client configurations for AWS Cognito Identity Provider client
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public SdkBuildTimeConfig sdk;
+
+    /**
+     * Sync HTTP transport configuration for Amazon Cognito Identity Provider client
+     */
+    @ConfigItem
+    public SyncHttpClientBuildTimeConfig syncClient;
+}

--- a/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsClientProducer.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsClientProducer.java
@@ -1,0 +1,53 @@
+package io.quarkus.amazon.cognitouserpools.runtime;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClientBuilder;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClientBuilder;
+
+@ApplicationScoped
+public class CognitoUserPoolsClientProducer {
+    private final CognitoIdentityProviderClient syncClient;
+    private final CognitoIdentityProviderAsyncClient asyncClient;
+
+    CognitoUserPoolsClientProducer(Instance<CognitoIdentityProviderClientBuilder> syncClientBuilderInstance,
+            Instance<CognitoIdentityProviderAsyncClientBuilder> asyncClientBuilderInstance) {
+        this.syncClient = syncClientBuilderInstance.isResolvable() ? syncClientBuilderInstance.get().build() : null;
+        this.asyncClient = asyncClientBuilderInstance.isResolvable() ? asyncClientBuilderInstance.get().build() : null;
+    }
+
+    @Produces
+    @ApplicationScoped
+    public CognitoIdentityProviderClient client() {
+        if (syncClient == null) {
+            throw new IllegalStateException(
+                    "The CognitoIdentityProviderClient is required but has not been detected/configured.");
+        }
+        return syncClient;
+    }
+
+    @Produces
+    @ApplicationScoped
+    public CognitoIdentityProviderAsyncClient asyncClient() {
+        if (asyncClient == null) {
+            throw new IllegalStateException(
+                    "The CognitoIdentityProviderAsyncClient is required but has not been detected/configured.");
+        }
+        return asyncClient;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (syncClient != null) {
+            syncClient.close();
+        }
+        if (asyncClient != null) {
+            asyncClient.close();
+        }
+    }
+}

--- a/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsConfig.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsConfig.java
@@ -1,0 +1,41 @@
+package io.quarkus.amazon.cognitouserpools.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "cognito-user-pools")
+public class CognitoUserPoolsConfig {
+    /**
+     * AWS SDK client configurations
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocSection
+    public SdkConfig sdk;
+
+    /**
+     * AWS services configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public AwsConfig aws;
+
+    /**
+     * Sync HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public SyncHttpClientConfig syncClient;
+
+    /**
+     * Netty HTTP transport configurations
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public NettyHttpClientConfig asyncClient;
+}

--- a/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
@@ -1,0 +1,59 @@
+package io.quarkus.amazon.cognitouserpools.runtime;
+
+import io.quarkus.amazon.common.runtime.AwsConfig;
+import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
+import io.quarkus.amazon.common.runtime.SdkConfig;
+import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.http.SdkHttpClient.Builder;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClientBuilder;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClientBuilder;
+
+@Recorder
+public class CognitoUserPoolsRecorder {
+    final CognitoUserPoolsConfig config;
+
+    public CognitoUserPoolsRecorder(CognitoUserPoolsConfig config) {
+        this.config = config;
+    }
+
+    public RuntimeValue<SyncHttpClientConfig> getSyncConfig() {
+        return new RuntimeValue<>(config.syncClient);
+    }
+
+    public RuntimeValue<NettyHttpClientConfig> getAsyncConfig() {
+        return new RuntimeValue<>(config.asyncClient);
+    }
+
+    public RuntimeValue<AwsConfig> getAwsConfig() {
+        return new RuntimeValue<>(config.aws);
+    }
+
+    public RuntimeValue<SdkConfig> getSdkConfig() {
+        return new RuntimeValue<>(config.sdk);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createSyncBuilder(RuntimeValue<Builder> transport) {
+        CognitoIdentityProviderClientBuilder builder = CognitoIdentityProviderClient.builder();
+
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+
+        CognitoIdentityProviderAsyncClientBuilder builder = CognitoIdentityProviderAsyncClient.builder();
+
+        if (transport != null) {
+            builder.httpClientBuilder(transport.getValue());
+        }
+        return new RuntimeValue<>(builder);
+    }
+}

--- a/cognito-user-pools/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/cognito-user-pools/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,17 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Amazon Cognito User Pools"
+metadata:
+  keywords:
+    - "cognito-user-pools"
+    - "cognitoidentityprovider"
+    - "cognito-identity-provider"
+    - "cognito-idp"
+    - "aws"
+    - "amazon"
+  guide: "https://quarkus.io/guides/amazon-cognitouserpools"
+  categories:
+    - "data"
+  status: "stable"
+  config:
+  - "quarkus.cognito-user-pools."

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[Quarkus Amazon Services]
+* xref:amazon-cognitouserpools.adoc[Cognito User Pools]
 * xref:amazon-dynamodb.adoc[DynamoDB]
 * xref:amazon-iam.adoc[IAM]
 * xref:amazon-kms.adoc[KMS]

--- a/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
@@ -1,0 +1,276 @@
+= Amazon Cognito User Pools Client
+
+include::./includes/attributes.adoc[]
+
+Service client for accessing Amazon Cognito user pools (Identity Provider).
+
+Using the Amazon Cognito user pools API, you can create a user pool to manage directories and users.
+You can authenticate a user to obtain tokens related to user identity and access policies.
+
+For more information, see the https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html[Amazon Cognito user pools] (https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cognitoidentityprovider/package-frame.html[AWS Java SDK 2.x docs]).
+
+
+NOTE: The Cognito User Pools extension is based on https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/welcome.html[AWS Java SDK 2.x].
+It's a major rewrite of the 1.x code base that offers two programming models (Blocking & Async).
+
+The Quarkus extension supports two programming models:
+
+* Blocking access using URL Connection HTTP client (by default) or the Apache HTTP Client
+* https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/basics-async.html[Asynchronous programming] based on JDK's `CompletableFuture` objects and the Netty HTTP client.
+
+In this guide, we see how you can get your REST services to use Cognito User Pool locally and on AWS.
+
+== Prerequisites
+
+To complete this guide, you need:
+
+* JDK 11+ installed with `JAVA_HOME` configured appropriately
+* an IDE
+* Apache Maven {maven-version}
+* One of:
+** An AWS Account to access the Cognito service
+** Or Docker for your system to run Cognito locally for testing purposes
+
+=== Set up Cognito locally
+
+The easiest way to start working with Cognito is to run a local mock instance as a container.
+
+[source,bash,subs="verbatim,attributes"]
+----
+docker run --rm --name moto -p 5000:5000 -d motoserver/moto:3.0.2
+----
+This starts a Cognito mock instance that is accessible on port `5000`.
+
+Create an AWS profile for your local instance using AWS CLI:
+[source,shell,subs="verbatim,attributes"]
+----
+$ aws configure --profile moto
+AWS Access Key ID [None]: test-key
+AWS Secret Access Key [None]: test-secret
+Default region name [None]: us-east-1
+Default output format [None]: test
+----
+
+=== Create a Cognito User Pool
+
+Create a Cognito user pool using AWS CLI.
+
+[source,bash,subs="verbatim,attributes"]
+----
+aws --profile moto --endpoint-url=http://localhost:5000 cognito-idp create-user-pool --pool-name quarkus-users-dev
+----
+
+Or, if you want to use your Cognito user pool on your AWS account create a user pool using your default profile
+[source,bash,subs="verbatim,attributes"]
+----
+aws cognito-user-pools cognito-idp --pool-name quarkus-users-dev
+----
+
+== Solution
+The application built here shows the count of Cognito User Pools in the current region.
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+
+== Creating the Maven project
+
+First, we need a new project. Create a new project with the following command:
+
+[source,bash,subs=attributes+]
+----
+mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=amazon-cognito-user-pools-quickstart \
+    -DclassName="org.acme.cognitouserpools.CognitoExampleResource" \
+    -Dpath="/cognito-example" \
+    -Dextensions="resteasy,resteasy-jackson,amazon-cognito-user-pools,resteasy-mutiny"
+cd amazon-cognito-user-pools-quickstart
+----
+
+This command generates a Maven structure importing the RESTEasy/JAX-RS, Mutiny and Amazon Cognito User Pool extensions.
+After this, the `amazon-cognito-user-pools` extension has been added to your `pom.xml` as well as the Mutiny support for RESTEasy.
+
+== Creating JSON REST service
+
+Edit a `org.acme.cognitouserpools.CognitoExampleResource` that will provide an API return count of Cognito User Pools using the synchronous client.
+
+[source,java]
+----
+package org.acme.cognitouserpools;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUserPoolsRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUserPoolsResponse;
+
+@Path("/cognito-example")
+public class CognitoExampleResource {
+    @Inject
+    CognitoIdentityProviderClient cognitoClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        ListUserPoolsRequest request = ListUserPoolsRequest.builder().build();
+        ListUserPoolsResponse response = cognitoClient.listUserPools(request);
+        return String.format("You have %d user pools", response.userPools().size());
+    }
+}
+----
+
+And update test class:
+
+[source,java]
+----
+package org.acme.cognitouserpools;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class CognitoExampleResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/cognito-example")
+          .then()
+             .statusCode(200)
+             .body(is("You have 1 user pools"));
+    }
+
+}
+----
+
+== Configuring Cognito User Pools clients
+
+Both Cognito clients (sync and async) are configurable via the `application.properties` file that
+can be provided in the `src/main/resources` directory.
+
+Additionally, you need to add to the classpath a proper implementation of the sync client.
+By default the extension uses the URL connection HTTP client, so you need to add a URL connection
+client dependency to the `pom.xml` file:
+
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>url-connection-client</artifactId>
+</dependency>
+----
+
+If you want to use Apache HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.cognito-user-pools.sync-client.type=apache
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>apache-client</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-apache-httpclient</artifactId>
+</dependency>
+----
+
+
+If you're going to use a local Cognito mock instance, configure it as follows:
+[source,properties]
+----
+quarkus.cognito-user-pools.endpoint-override=http://localhost:5000
+
+quarkus.cognito-user-pools.aws.region=eu-west-1
+quarkus.cognito-user-pools.aws.credentials.type=static
+quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id=test-key
+quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key=test-secret
+----
+
+- `quarkus.cognito-user-pools.aws.region` - It's required by the client, but since you're using a local Cognito mock instance use `us-east-1` as it's a default region of moto.
+- `quarkus.cognito-user-pools.aws.credentials` - Set `static` credentials provider with any values for `access-key-id` and `secret-access-key`
+- `quarkus.cognito-user-pools.endpoint-override` - Override the Cognito User Pools client to use a local instance instead of an AWS service
+
+If you want to work with an AWS account, you can simply remove or comment out all Cognito User Pools
+related properties. By default, the Cognito User Pools client extension will use the `default`
+credentials provider chain that looks for credentials in this order:
+
+include::./amazon-credentials.adoc[]
+
+And the region from your AWS CLI profile will be used.
+
+== Next steps
+
+=== Packaging
+
+Packaging your application is as simple as `./mvnw clean package`.
+It can be run with `java -jar target/quarkus-app/quarkus-run.jar`.
+
+With GraalVM installed, you can also create a native executable binary: `./mvnw clean package -Dnative`.
+Depending on your system, that will take some time.
+
+=== Going asynchronous
+
+Thanks to the AWS SDK v2.x used by the Quarkus extension, you can use the asynchronous programming model out of the box.
+
+Create a `org.acme.cognitouserpools.CognitoAsyncExampleResource` REST resource that will be similar to our
+`CognitoExampleResource` but using an asynchronous programming model.
+
+[source,java]
+----
+package org.acme.cognitouserpools;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.smallrye.mutiny.Uni;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUserPoolsRequest;
+
+@Path("/cognito-async-example")
+public class CognitoAsyncExampleResource {
+    @Inject
+    CognitoIdentityProviderAsyncClient cognitoAsyncClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> hello() {
+        ListUserPoolsRequest request = ListUserPoolsRequest.builder().build();
+        return Uni
+            .createFrom()
+            .completionStage(cognitoAsyncClient.listUserPools(request))
+            .map(response -> {
+                return String.format("You have %d user pools", response.userPools().size());
+            });
+    }
+}
+----
+We create `Uni` instances from the `CompletionStage` objects returned by the asynchronous Cognito
+Identity Provider client, and then transform the emitted item.
+
+And we need to add the Netty HTTP client dependency to the `pom.xml`:
+
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>netty-nio-client</artifactId>
+</dependency>
+----
+
+== Configuration Reference
+
+include::./includes/quarkus-amazon-cognitouserpools.adoc[]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
@@ -1,0 +1,822 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[[quarkus-amazon-cognitouserpools_configuration]]link:#quarkus-amazon-cognitouserpools_configuration[Configuration property]
+
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.interceptors]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.interceptors[quarkus.cognito-user-pools.interceptors]`
+
+[.description]
+--
+List of execution interceptors that will have access to read and modify the request and response objects as they are processed by the AWS SDK. 
+ The list should consists of class names which implements `software.amazon.awssdk.core.interceptor.ExecutionInterceptor` interface.
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.type[quarkus.cognito-user-pools.sync-client.type]`
+
+[.description]
+--
+Type of the sync HTTP client implementation
+--|`url`, `apache` 
+|`url`
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sdk-aws-sdk-client-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sdk-aws-sdk-client-configurations[AWS SDK client configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.endpoint-override]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.endpoint-override[quarkus.cognito-user-pools.endpoint-override]`
+
+[.description]
+--
+The endpoint URI with which the SDK should communicate. 
+ If not specified, an appropriate endpoint to be used for the given service and region.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.api-call-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.api-call-timeout[quarkus.cognito-user-pools.api-call-timeout]`
+
+[.description]
+--
+The amount of time to allow the client to complete the execution of an API call. 
+ This timeout covers the entire client execution except for marshalling. This includes request handler execution, all HTTP requests including retries, unmarshalling, etc. 
+ This value should always be positive, if present.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.api-call-attempt-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.api-call-attempt-timeout[quarkus.cognito-user-pools.api-call-attempt-timeout]`
+
+[.description]
+--
+The amount of time to wait for the HTTP request to complete before giving up and timing out. 
+ This value should always be positive, if present.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws-aws-services-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws-aws-services-configurations[AWS services configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.region]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.region[quarkus.cognito-user-pools.aws.region]`
+
+[.description]
+--
+An Amazon Web Services region that hosts the given service.
+
+It overrides region provider chain with static value of
+region with which the service client should communicate.
+
+If not set, region is retrieved via the default providers chain in the following order:
+
+* `aws.region` system property
+* `region` property from the profile file
+* Instance profile file
+
+See `software.amazon.awssdk.regions.Region` for available regions.
+--|Region 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.type[quarkus.cognito-user-pools.aws.credentials.type]`
+
+[.description]
+--
+Configure the credentials provider that should be used to authenticate with AWS.
+
+Available values:
+
+* `default` - the provider will attempt to identify the credentials automatically using the following checks:
+** Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
+** Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+** Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
+** Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable.
+** Instance profile credentials delivered through the Amazon EC2 metadata service
+* `static` - the provider that uses the access key and secret access key specified in the `static-provider` section of the config.
+* `system-property` - it loads credentials from the `aws.accessKeyId`, `aws.secretAccessKey` and `aws.sessionToken` system properties.
+* `env-variable` - it loads credentials from the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
+* `profile` - credentials are based on AWS configuration profiles. This loads credentials from
+              a http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[profile file],
+              allowing you to share multiple sets of AWS security credentials between different tools like the AWS SDK for Java and the AWS CLI.
+* `container` - It loads credentials from a local metadata service. Containers currently supported by the AWS SDK are
+                **Amazon Elastic Container Service (ECS)** and **AWS Greengrass**
+* `instance-profile` - It loads credentials from the Amazon EC2 Instance Metadata Service.
+* `process` - Credentials are loaded from an external process. This is used to support the credential_process setting in the profile
+              credentials file. See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes[Sourcing Credentials From External Processes]
+              for more information.
+* `anonymous` - It always returns anonymous AWS credentials. Anonymous AWS credentials result in un-authenticated requests and will
+                fail unless the resource or API's policy has been configured to specifically allow anonymous access.
+--|`default`, `static`, `system-property`, `env-variable`, `profile`, `container`, `instance-profile`, `process`, `anonymous` 
+|`default`
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider-default-credentials-provider-configuration]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider-default-credentials-provider-configuration[Default credentials provider configuration]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider.async-credential-update-enabled[quarkus.cognito-user-pools.aws.credentials.default-provider.async-credential-update-enabled]`
+
+[.description]
+--
+Whether this provider should fetch credentials asynchronously in the background. 
+ If this is `true`, threads are less likely to block, but additional resources are used to maintain the provider.
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.cognito-user-pools.aws.credentials.default-provider.reuse-last-provider-enabled]`
+
+[.description]
+--
+Whether the provider should reuse the last successful credentials provider in the chain. 
+ Reusing the last successful credentials provider will typically return credentials faster than searching through the chain.
+--|boolean 
+|`true`
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider-static-credentials-provider-configuration]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider-static-credentials-provider-configuration[Static credentials provider configuration]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id[quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id]`
+
+[.description]
+--
+AWS Access key id
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key[quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key]`
+
+[.description]
+--
+AWS Secret access key
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.session-token]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.static-provider.session-token[quarkus.cognito-user-pools.aws.credentials.static-provider.session-token]`
+
+[.description]
+--
+AWS Session token
+--|string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration[AWS Profile credentials provider configuration]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.profile-provider.profile-name]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.profile-provider.profile-name[quarkus.cognito-user-pools.aws.credentials.profile-provider.profile-name]`
+
+[.description]
+--
+The name of the profile that should be used by this credentials provider. 
+ If not specified, the value in `AWS_PROFILE` environment variable or `aws.profile` system property is used and defaults to `default` name.
+--|string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider-process-credentials-provider-configuration]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider-process-credentials-provider-configuration[Process credentials provider configuration]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.async-credential-update-enabled[quarkus.cognito-user-pools.aws.credentials.process-provider.async-credential-update-enabled]`
+
+[.description]
+--
+Whether the provider should fetch credentials asynchronously in the background. 
+ If this is true, threads are less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.credential-refresh-threshold[quarkus.cognito-user-pools.aws.credentials.process-provider.credential-refresh-threshold]`
+
+[.description]
+--
+The amount of time between when the credentials expire and when the credentials should start to be refreshed. 
+ This allows the credentials to be refreshed ++*++before++*++ they are reported to expire.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`15S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.process-output-limit[quarkus.cognito-user-pools.aws.credentials.process-provider.process-output-limit]`
+
+[.description]
+--
+The maximum size of the output that can be returned by the external process before an exception is raised.
+--|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
+|`1024`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.command]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.aws.credentials.process-provider.command[quarkus.cognito-user-pools.aws.credentials.process-provider.command]`
+
+[.description]
+--
+The command that should be executed to retrieve credentials.
+--|string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client-sync-http-transport-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client-sync-http-transport-configurations[Sync HTTP transport configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.connection-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.connection-timeout[quarkus.cognito-user-pools.sync-client.connection-timeout]`
+
+[.description]
+--
+The maximum amount of time to establish a connection before timing out.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`2S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.socket-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.socket-timeout[quarkus.cognito-user-pools.sync-client.socket-timeout]`
+
+[.description]
+--
+The amount of time to wait for data to be transferred over an established, open connection before the connection is timed out.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`30S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.type[quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.type]`
+
+[.description]
+--
+TLS key managers provider type.
+
+Available providers:
+
+* `none` - Use this provider if you don't want the client to present any certificates to the remote TLS host.
+* `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
+                      `javax.net.ssl.keyStoreType` properties defined by the
+                       https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
+* `file-store` - Provider that loads a the key store from a file.
+--|`none`, `system-property`, `file-store` 
+|`system-property`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.path]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.path[quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.path]`
+
+[.description]
+--
+Path to the key store.
+--|path 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.type[quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.type]`
+
+[.description]
+--
+Key store type. 
+ See the KeyStore section in the https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html++#++KeyStore++[++Java Cryptography Architecture Standard Algorithm Name Documentation++]++ for information about standard keystore types.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.password[quarkus.cognito-user-pools.sync-client.tls-key-managers-provider.file-store.password]`
+
+[.description]
+--
+Key store password
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.type[quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.type]`
+
+[.description]
+--
+TLS trust managers provider type.
+
+Available providers:
+
+* `trust-all` - Use this provider to disable the validation of servers certificates and therefor turst all server certificates.
+* `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
+                      `javax.net.ssl.keyStoreType` properties defined by the
+                       https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
+* `file-store` - Provider that loads a the key store from a file.
+--|`trust-all`, `system-property`, `file-store` 
+|`system-property`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.path]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.path[quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.path]`
+
+[.description]
+--
+Path to the key store.
+--|path 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.type[quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.type]`
+
+[.description]
+--
+Key store type. 
+ See the KeyStore section in the https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html++#++KeyStore++[++Java Cryptography Architecture Standard Algorithm Name Documentation++]++ for information about standard keystore types.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.password[quarkus.cognito-user-pools.sync-client.tls-trust-managers-provider.file-store.password]`
+
+[.description]
+--
+Key store password
+--|string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache-apache-http-client-specific-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache-apache-http-client-specific-configurations[Apache HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-acquisition-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-acquisition-timeout[quarkus.cognito-user-pools.sync-client.apache.connection-acquisition-timeout]`
+
+[.description]
+--
+The amount of time to wait when acquiring a connection from the pool before giving up and timing out.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`10S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-max-idle-time]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-max-idle-time[quarkus.cognito-user-pools.sync-client.apache.connection-max-idle-time]`
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-time-to-live]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.connection-time-to-live[quarkus.cognito-user-pools.sync-client.apache.connection-time-to-live]`
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open, regardless of usage frequency.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.max-connections]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.max-connections[quarkus.cognito-user-pools.sync-client.apache.max-connections]`
+
+[.description]
+--
+The maximum number of connections allowed in the connection pool. 
+ Each built HTTP client has its own private connection pool.
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.expect-continue-enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.expect-continue-enabled[quarkus.cognito-user-pools.sync-client.apache.expect-continue-enabled]`
+
+[.description]
+--
+Whether the client should send an HTTP expect-continue handshake before each request.
+--|boolean 
+|`true`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.use-idle-connection-reaper]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.use-idle-connection-reaper[quarkus.cognito-user-pools.sync-client.apache.use-idle-connection-reaper]`
+
+[.description]
+--
+Whether the idle connections in the connection pool should be closed asynchronously. 
+ When enabled, connections left idling for longer than `quarkus..sync-client.connection-max-idle-time` will be closed. This will not close connections currently in use.
+--|boolean 
+|`true`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.enabled[quarkus.cognito-user-pools.sync-client.apache.proxy.enabled]`
+
+[.description]
+--
+Enable HTTP proxy
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.endpoint]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.endpoint[quarkus.cognito-user-pools.sync-client.apache.proxy.endpoint]`
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through. 
+ Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.username]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.username[quarkus.cognito-user-pools.sync-client.apache.proxy.username]`
+
+[.description]
+--
+The username to use when connecting through a proxy.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.password[quarkus.cognito-user-pools.sync-client.apache.proxy.password]`
+
+[.description]
+--
+The password to use when connecting through a proxy.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-domain]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-domain[quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-domain]`
+
+[.description]
+--
+For NTLM proxies - the Windows domain name to use when authenticating with the proxy.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-workstation]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-workstation[quarkus.cognito-user-pools.sync-client.apache.proxy.ntlm-workstation]`
+
+[.description]
+--
+For NTLM proxies - the Windows workstation name to use when authenticating with the proxy.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.preemptive-basic-authentication-enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.preemptive-basic-authentication-enabled[quarkus.cognito-user-pools.sync-client.apache.proxy.preemptive-basic-authentication-enabled]`
+
+[.description]
+--
+Whether to attempt to authenticate preemptively against the proxy server using basic authentication.
+--|boolean 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.non-proxy-hosts]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.non-proxy-hosts[quarkus.cognito-user-pools.sync-client.apache.proxy.non-proxy-hosts]`
+
+[.description]
+--
+The hosts that the client is allowed to access without going through the proxy.
+--|list of string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client-netty-http-transport-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client-netty-http-transport-configurations[Netty HTTP transport configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.max-concurrency]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.max-concurrency[quarkus.cognito-user-pools.async-client.max-concurrency]`
+
+[.description]
+--
+The maximum number of allowed concurrent requests. 
+ For HTTP/1.1 this is the same as max connections. For HTTP/2 the number of connections that will be used depends on the max streams allowed per connection.
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.max-pending-connection-acquires]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.max-pending-connection-acquires[quarkus.cognito-user-pools.async-client.max-pending-connection-acquires]`
+
+[.description]
+--
+The maximum number of pending acquires allowed. 
+ Once this exceeds, acquire tries will be failed.
+--|int 
+|`10000`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.read-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.read-timeout[quarkus.cognito-user-pools.async-client.read-timeout]`
+
+[.description]
+--
+The amount of time to wait for a read on a socket before an exception is thrown. 
+ Specify `0` to disable.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`30S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.write-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.write-timeout[quarkus.cognito-user-pools.async-client.write-timeout]`
+
+[.description]
+--
+The amount of time to wait for a write on a socket before an exception is thrown. 
+ Specify `0` to disable.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`30S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-timeout[quarkus.cognito-user-pools.async-client.connection-timeout]`
+
+[.description]
+--
+The amount of time to wait when initially establishing a connection before giving up and timing out.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`10S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-acquisition-timeout]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-acquisition-timeout[quarkus.cognito-user-pools.async-client.connection-acquisition-timeout]`
+
+[.description]
+--
+The amount of time to wait when acquiring a connection from the pool before giving up and timing out.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`2S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-time-to-live]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-time-to-live[quarkus.cognito-user-pools.async-client.connection-time-to-live]`
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open, regardless of usage frequency.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-max-idle-time]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.connection-max-idle-time[quarkus.cognito-user-pools.async-client.connection-max-idle-time]`
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle. 
+ Currently has no effect if `quarkus..async-client.use-idle-connection-reaper` is false.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`5S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.use-idle-connection-reaper]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.use-idle-connection-reaper[quarkus.cognito-user-pools.async-client.use-idle-connection-reaper]`
+
+[.description]
+--
+Whether the idle connections in the connection pool should be closed. 
+ When enabled, connections left idling for longer than `quarkus..async-client.connection-max-idle-time` will be closed. This will not close connections currently in use.
+--|boolean 
+|`true`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.protocol]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.protocol[quarkus.cognito-user-pools.async-client.protocol]`
+
+[.description]
+--
+The HTTP protocol to use.
+--|`http1-1`, `http2` 
+|`http1-1`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.ssl-provider]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.ssl-provider[quarkus.cognito-user-pools.async-client.ssl-provider]`
+
+[.description]
+--
+The SSL Provider to be used in the Netty client. 
+ Default is `OPENSSL` if available, `JDK` otherwise.
+--|`jdk`, `openssl`, `openssl-refcnt` 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.max-streams]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.max-streams[quarkus.cognito-user-pools.async-client.http2.max-streams]`
+
+[.description]
+--
+The maximum number of concurrent streams for an HTTP/2 connection. 
+ This setting is only respected when the HTTP/2 protocol is used.
+--|long 
+|`4294967295`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.initial-window-size]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.initial-window-size[quarkus.cognito-user-pools.async-client.http2.initial-window-size]`
+
+[.description]
+--
+The initial window size for an HTTP/2 stream. 
+ This setting is only respected when the HTTP/2 protocol is used.
+--|int 
+|`1048576`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.health-check-ping-period]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.http2.health-check-ping-period[quarkus.cognito-user-pools.async-client.http2.health-check-ping-period]`
+
+[.description]
+--
+Sets the period that the Netty client will send `PING` frames to the remote endpoint to check the health of the connection. To disable this feature, set a duration of 0. 
+ This setting is only respected when the HTTP/2 protocol is used.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor[icon:question-circle[], title=More information about the Duration format]
+|`5`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.enabled[quarkus.cognito-user-pools.async-client.proxy.enabled]`
+
+[.description]
+--
+Enable HTTP proxy.
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.endpoint]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.endpoint[quarkus.cognito-user-pools.async-client.proxy.endpoint]`
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through. 
+ Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.non-proxy-hosts]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.proxy.non-proxy-hosts[quarkus.cognito-user-pools.async-client.proxy.non-proxy-hosts]`
+
+[.description]
+--
+The hosts that the client is allowed to access without going through the proxy.
+--|list of string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.type[quarkus.cognito-user-pools.async-client.tls-key-managers-provider.type]`
+
+[.description]
+--
+TLS key managers provider type.
+
+Available providers:
+
+* `none` - Use this provider if you don't want the client to present any certificates to the remote TLS host.
+* `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
+                      `javax.net.ssl.keyStoreType` properties defined by the
+                       https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
+* `file-store` - Provider that loads a the key store from a file.
+--|`none`, `system-property`, `file-store` 
+|`system-property`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.path]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.path[quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.path]`
+
+[.description]
+--
+Path to the key store.
+--|path 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.type[quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.type]`
+
+[.description]
+--
+Key store type. 
+ See the KeyStore section in the https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html++#++KeyStore++[++Java Cryptography Architecture Standard Algorithm Name Documentation++]++ for information about standard keystore types.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.password[quarkus.cognito-user-pools.async-client.tls-key-managers-provider.file-store.password]`
+
+[.description]
+--
+Key store password
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.type[quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.type]`
+
+[.description]
+--
+TLS trust managers provider type.
+
+Available providers:
+
+* `trust-all` - Use this provider to disable the validation of servers certificates and therefor turst all server certificates.
+* `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
+                      `javax.net.ssl.keyStoreType` properties defined by the
+                       https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
+* `file-store` - Provider that loads a the key store from a file.
+--|`trust-all`, `system-property`, `file-store` 
+|`system-property`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.path]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.path[quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.path]`
+
+[.description]
+--
+Path to the key store.
+--|path 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.type[quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.type]`
+
+[.description]
+--
+Key store type. 
+ See the KeyStore section in the https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html++#++KeyStore++[++Java Cryptography Architecture Standard Algorithm Name Documentation++]++ for information about standard keystore types.
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.password[quarkus.cognito-user-pools.async-client.tls-trust-managers-provider.file-store.password]`
+
+[.description]
+--
+Key store password
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.override]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.override[quarkus.cognito-user-pools.async-client.event-loop.override]`
+
+[.description]
+--
+Enable the custom configuration of the Netty event loop group.
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.number-of-threads]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.number-of-threads[quarkus.cognito-user-pools.async-client.event-loop.number-of-threads]`
+
+[.description]
+--
+Number of threads to use for the event loop group. 
+ If not set, the default Netty thread count is used (which is double the number of available processors unless the `io.netty.eventLoopThreads` system property is set.
+--|int 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.thread-name-prefix]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.event-loop.thread-name-prefix[quarkus.cognito-user-pools.async-client.event-loop.thread-name-prefix]`
+
+[.description]
+--
+The thread name prefix for threads created by this thread factory used by event loop group. 
+ The prefix will be appended with a number unique to the thread factory and a number unique to the thread. 
+ If not specified it defaults to `aws-java-sdk-NettyEventLoop`
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.advanced.use-future-completion-thread-pool[quarkus.cognito-user-pools.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
+|===
+ifndef::no-duration-note[]
+[NOTE]
+[[duration-note-anchor]]
+.About the Duration format
+====
+The format for durations uses the standard `java.time.Duration` format.
+You can learn more about it in the link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-[Duration#parse() javadoc].
+
+You can also provide duration values starting with a number.
+In this case, if the value consists only of a number, the converter treats the value as seconds.
+Otherwise, `PT` is implicitly prepended to the value to obtain a standard `java.time.Duration` format.
+====
+endif::no-duration-note[]
+
+[NOTE]
+[[memory-size-note-anchor]]
+.About the MemorySize format
+====
+A size configuration option recognises string in this format (shown as a regular expression): `[0-9]+[KkMmGgTtPpEeZzYy]?`.
+If no suffix is given, assume bytes.
+====

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>quarkus-amazon-ssm-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-cognito-user-pools-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -108,6 +113,7 @@
                                         <include>quarkus-amazon-sns.adoc</include>
                                         <include>quarkus-amazon-sqs.adoc</include>
                                         <include>quarkus-amazon-ssm.adoc</include>
+                                        <include>quarkus-amazon-cognitouserpools.adoc</include>
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,6 +21,7 @@
         <iam.url>http://localhost:4566</iam.url>
         <ssm.url>http://localhost:4566</ssm.url>
         <secretsmanager.url>http://localhost:4566</secretsmanager.url>
+        <cognitoidentity.url>http://localhost:5000</cognitoidentity.url>
     </properties>
 
     <dependencies>
@@ -71,6 +72,10 @@
         <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
             <artifactId>quarkus-amazon-secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -158,6 +158,22 @@
                                 </wait>
                             </run>
                         </image>
+                        <image>
+                            <name>motoserver/moto:3.0.2</name>
+                            <alias>aws-moto</alias>
+                            <run>
+                                <env>
+                                </env>
+                                <ports>
+                                    <port>5000:5000</port>
+                                </ports>
+                                <log />
+                                <wait>
+                                    <time>30000</time>
+                                    <log>^ \* Running on</log>
+                                </wait>
+                            </run>
+                        </image>
                     </images>
                     <!--Stops all dynamodb images currently running, not just those we just started.
                       Useful to stop processes still running from a previously failed integration test run -->

--- a/integration-tests/src/main/java/io/quarkus/it/amazon/cognitouserpools/CognitoUserPoolsResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/amazon/cognitouserpools/CognitoUserPoolsResource.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.amazon.cognitouserpools;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUserPoolsRequest;
+
+@Path("/cognito-user-pools")
+public class CognitoUserPoolsResource {
+    @Inject
+    CognitoIdentityProviderClient cognitoIdpClient;
+
+    @Inject
+    CognitoIdentityProviderAsyncClient cognitoIdpAsyncClient;
+
+    @GET
+    @Path("/sync")
+    @Produces(TEXT_PLAIN)
+    public String testSync() {
+        final ListUserPoolsRequest listRequest = ListUserPoolsRequest.builder().build();
+        cognitoIdpClient.listUserPools(listRequest);
+        return "sync-success";
+    }
+
+    @GET
+    @Path("/async")
+    @Produces(TEXT_PLAIN)
+    public CompletionStage<String> testAsync() {
+        final ListUserPoolsRequest listRequest = ListUserPoolsRequest.builder().build();
+        return cognitoIdpAsyncClient
+                .listUserPools(listRequest)
+                .thenApply(response -> "async-success");
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -55,3 +55,9 @@ quarkus.secretsmanager.aws.region=us-east-1
 quarkus.secretsmanager.aws.credentials.type=static
 quarkus.secretsmanager.aws.credentials.static-provider.access-key-id=test-key
 quarkus.secretsmanager.aws.credentials.static-provider.secret-access-key=test-secret
+
+quarkus.cognito-user-pools.endpoint-override=${cognitoidentity.url}
+quarkus.cognito-user-pools.aws.region=us-east-1
+quarkus.cognito-user-pools.aws.credentials.type=static
+quarkus.cognito-user-pools.aws.credentials.static-provider.access-key-id=test-key
+quarkus.cognito-user-pools.aws.credentials.static-provider.secret-access-key=test-secret

--- a/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonCognitoUserPoolsITCase.java
+++ b/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonCognitoUserPoolsITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.amazon;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class AmazonCognitoUserPoolsITCase extends AmazonCognitoUserPoolsTest {
+}

--- a/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonCognitoUserPoolsTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonCognitoUserPoolsTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.amazon;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class AmazonCognitoUserPoolsTest {
+    @Test
+    public void testAsync() {
+        RestAssured.when().get("/test/cognito-user-pools/async")
+                .then().body(is("async-success"));
+    }
+
+    @Test
+    public void testSync() {
+        RestAssured.when().get("/test/cognito-user-pools/sync")
+                .then().body(is("sync-success"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>bom</module>
         <module>build-parent</module>
+        <module>cognito-user-pools</module>
         <module>common</module>
         <module>dynamodb</module>
         <module>iam</module>


### PR DESCRIPTION
Hi, I have the intention to add support for Cognito Identity Provider API clients to this set of extensions. I am using Quarkus on the current project and in the near future I will implement user management, which we store in the Cognito User Pool.

My proposed implementation of the extension for Cognito User Pools I did by analogy with the current implementation of the extension for SQS.

I have successfully tested the injection and configuration of synchronous and asynchronous clients. And build a native image with a new extension. I checked the steps from the documentation locally, except for generating a project with the extension connected.

I have now implemented the following:
- Synchronous and asynchronous client configuration
- Provider for synchronous and asynchronous client
- Two unit tests for configurations (valid and invalid)
- Simple integration test
- Generation of documentation for the configuration
- Wrote simple documentation

I added `motoserver` to the integration tests because local-stack supports Cognito only in the Pro version.

Do I have a chance of accepting these changes? And what else do I need to do to increase my chances?