### PR TITLE
Skipping client processing now includes a check for presigners

### DIFF
--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
@@ -177,7 +177,7 @@ abstract public class AbstractAmazonServiceProcessor {
                 .map(c -> c.getClientBuilder())
                 .findFirst();
 
-        if (!syncSdkHttpClientBuilder.isPresent() && !asyncSdkAsyncHttpClientBuilder.isPresent()) {
+        if (!syncSdkHttpClientBuilder.isPresent() && !asyncSdkAsyncHttpClientBuilder.isPresent() && presignerBuilder == null) {
             return;
         }
 


### PR DESCRIPTION
Previously the early out meant that presigners were not available when one of the related clients are not injected. Fixed by taking the presigner into account before early exit.

Fixes #63.

This should probably include a test but to test it we'd need to replicate the `integration-test` module into a new module to test this specific case. It's been verified locally.