### PR TITLE
add ability to disable thread pool used to complete futures in async clients

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
@@ -126,6 +126,12 @@ public class NettyHttpClientConfig {
     @ConfigItem
     public SdkEventLoopGroupConfig eventLoop;
 
+    /**
+     * Async client advanced options
+     */
+    @ConfigItem
+    public Advanced advanced;
+
     @ConfigGroup
     public static class Http2Config {
         /**
@@ -209,6 +215,18 @@ public class NettyHttpClientConfig {
          */
         @ConfigItem
         public Optional<List<String>> nonProxyHosts;
+    }
+
+    @ConfigGroup
+    public static class Advanced {
+
+        /**
+         * Whether the default thread pool should be used to complete the futures returned from the HTTP client request.
+         * <p>
+         * When disabled, futures will be completed on the Netty event loop thread.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean useFutureCompletionThreadPool;
     }
 
     //TODO: additionalChannelOptions

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
@@ -788,6 +788,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.advanced.use-future-completion-thread-pool[quarkus.dynamodb.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-iam_quarkus.iam.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-iam_quarkus.iam.async-client.advanced.use-future-completion-thread-pool[quarkus.iam.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-kms_quarkus.kms.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-kms_quarkus.kms.async-client.advanced.use-future-completion-thread-pool[quarkus.kms.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
@@ -844,6 +844,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-s3_quarkus.s3.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-s3_quarkus.s3.async-client.advanced.use-future-completion-thread-pool[quarkus.s3.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.advanced.use-future-completion-thread-pool[quarkus.secretsmanager.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-ses_quarkus.ses.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-ses_quarkus.ses.async-client.advanced.use-future-completion-thread-pool[quarkus.ses.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-sns_quarkus.sns.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-sns_quarkus.sns.async-client.advanced.use-future-completion-thread-pool[quarkus.sns.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-sqs_quarkus.sqs.async-client.advanced.use-future-completion-thread-pool[quarkus.sqs.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
@@ -779,6 +779,16 @@ The thread name prefix for threads created by this thread factory used by event 
 --|string 
 |
 
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.async-client.advanced.use-future-completion-thread-pool]]`link:#quarkus-amazon-ssm_quarkus.ssm.async-client.advanced.use-future-completion-thread-pool[quarkus.ssm.async-client.advanced.use-future-completion-thread-pool]`
+
+[.description]
+--
+Whether the default thread pool should be used to complete the futures returned from the HTTP client request. 
+ When disabled, futures will be completed on the Netty event loop thread.
+--|boolean 
+|`true`
+
 |===
 ifndef::no-duration-note[]
 [NOTE]

--- a/dynamodb/runtime/src/main/java/io/quarkus/amazon/dynamodb/runtime/DynamodbRecorder.java
+++ b/dynamodb/runtime/src/main/java/io/quarkus/amazon/dynamodb/runtime/DynamodbRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
@@ -56,6 +57,10 @@ public class DynamodbRecorder {
 
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/iam/runtime/src/main/java/io/quarkus/amazon/iam/runtime/IamRecorder.java
+++ b/iam/runtime/src/main/java/io/quarkus/amazon/iam/runtime/IamRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.iam.IamAsyncClient;
@@ -52,6 +53,10 @@ public class IamRecorder {
         IamAsyncClientBuilder builder = IamAsyncClient.builder();
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/kms/runtime/src/main/java/io/quarkus/amazon/kms/runtime/KmsRecorder.java
+++ b/kms/runtime/src/main/java/io/quarkus/amazon/kms/runtime/KmsRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.kms.KmsAsyncClient;
@@ -52,6 +53,10 @@ public class KmsRecorder {
         KmsAsyncClientBuilder builder = KmsAsyncClient.builder();
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/s3/runtime/src/main/java/io/quarkus/amazon/s3/runtime/S3Recorder.java
+++ b/s3/runtime/src/main/java/io/quarkus/amazon/s3/runtime/S3Recorder.java
@@ -8,6 +8,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.presigner.SdkPresigner;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient.Builder;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -60,6 +61,10 @@ public class S3Recorder {
 
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerRecorder.java
+++ b/secretsmanager/runtime/src/main/java/io/quarkus/amazon/secretsmanager/runtime/SecretsManagerRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
@@ -48,6 +49,10 @@ public class SecretsManagerRecorder {
         SecretsManagerAsyncClientBuilder builder = SecretsManagerAsyncClient.builder();
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/sns/runtime/src/main/java/io/quarkus/amazon/sns/runtime/SnsRecorder.java
+++ b/sns/runtime/src/main/java/io/quarkus/amazon/sns/runtime/SnsRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient.Builder;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
@@ -53,6 +54,10 @@ public class SnsRecorder {
 
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/sqs/runtime/src/main/java/io/quarkus/amazon/sqs/runtime/SqsRecorder.java
+++ b/sqs/runtime/src/main/java/io/quarkus/amazon/sqs/runtime/SqsRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient.Builder;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
@@ -53,6 +54,10 @@ public class SqsRecorder {
 
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }

--- a/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmRecorder.java
+++ b/ssm/runtime/src/main/java/io/quarkus/amazon/ssm/runtime/SsmRecorder.java
@@ -7,6 +7,7 @@ import io.quarkus.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.ssm.SsmAsyncClient;
@@ -47,6 +48,10 @@ public class SsmRecorder {
         SsmAsyncClientBuilder builder = SsmAsyncClient.builder();
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
+        }
+        if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
         }
         return new RuntimeValue<>(builder);
     }


### PR DESCRIPTION
This PR introduces a new config option available to all the AWS extensions, making it possible to disable the default 50 thread pool described here: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/asynchronous.html#advanced-operations

(replaces #104)