### PR TITLE
fix: honor tls config when not setting file-store property

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AbstractAmazonClientTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AbstractAmazonClientTransportRecorder.java
@@ -1,7 +1,6 @@
 package io.quarkus.amazon.common.runtime;
 
 import java.net.URI;
-import java.util.Optional;
 
 import io.quarkus.runtime.RuntimeValue;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -24,18 +23,12 @@ public abstract class AbstractAmazonClientTransportRecorder {
         throw new IllegalStateException("Configuring an async client is not supported by " + this.getClass().getName());
     }
 
-    protected Optional<TlsKeyManagersProvider> getTlsKeyManagersProvider(TlsKeyManagersProviderConfig config) {
-        if (config.fileStore != null && config.fileStore.path.isPresent() && config.fileStore.type.isPresent()) {
-            return Optional.of(config.type.create(config));
-        }
-        return Optional.empty();
+    protected TlsKeyManagersProvider getTlsKeyManagersProvider(TlsKeyManagersProviderConfig config) {
+        return config.type.create(config);
     }
 
-    protected Optional<TlsTrustManagersProvider> getTlsTrustManagersProvider(TlsTrustManagersProviderConfig config) {
-        if (config.fileStore != null && config.fileStore.path.isPresent() && config.fileStore.type.isPresent()) {
-            return Optional.of(config.type.create(config));
-        }
-        return Optional.empty();
+    protected TlsTrustManagersProvider getTlsTrustManagersProvider(TlsTrustManagersProviderConfig config) {
+        return config.type.create(config);
     }
 
     protected void validateProxyEndpoint(String extension, URI endpoint, String clientType) {

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientApacheTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientApacheTransportRecorder.java
@@ -42,8 +42,8 @@ public class AmazonClientApacheTransportRecorder extends AbstractAmazonClientTra
 
             builder.proxyConfiguration(proxyBuilder.build());
         }
-        getTlsKeyManagersProvider(syncConfig.tlsKeyManagersProvider).ifPresent(builder::tlsKeyManagersProvider);
-        getTlsTrustManagersProvider(syncConfig.tlsTrustManagersProvider).ifPresent(builder::tlsTrustManagersProvider);
+        builder.tlsKeyManagersProvider(getTlsKeyManagersProvider(syncConfig.tlsKeyManagersProvider));
+        builder.tlsTrustManagersProvider(getTlsTrustManagersProvider(syncConfig.tlsTrustManagersProvider));
         return new RuntimeValue<>(builder);
     }
 

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
@@ -54,8 +54,8 @@ public class AmazonClientNettyTransportRecorder extends AbstractAmazonClientTran
             builder.proxyConfiguration(proxyBuilder.build());
         }
 
-        getTlsKeyManagersProvider(asyncConfig.tlsKeyManagersProvider).ifPresent(builder::tlsKeyManagersProvider);
-        getTlsTrustManagersProvider(asyncConfig.tlsTrustManagersProvider).ifPresent(builder::tlsTrustManagersProvider);
+        builder.tlsKeyManagersProvider(getTlsKeyManagersProvider(asyncConfig.tlsKeyManagersProvider));
+        builder.tlsTrustManagersProvider(getTlsTrustManagersProvider(asyncConfig.tlsTrustManagersProvider));
 
         if (asyncConfig.eventLoop.override) {
             SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientUrlConnectionTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientUrlConnectionTransportRecorder.java
@@ -18,8 +18,8 @@ public class AmazonClientUrlConnectionTransportRecorder extends AbstractAmazonCl
         UrlConnectionHttpClient.Builder builder = UrlConnectionHttpClient.builder();
         builder.connectionTimeout(syncConfig.connectionTimeout);
         builder.socketTimeout(syncConfig.socketTimeout);
-        getTlsKeyManagersProvider(syncConfig.tlsKeyManagersProvider).ifPresent(builder::tlsKeyManagersProvider);
-        getTlsTrustManagersProvider(syncConfig.tlsTrustManagersProvider).ifPresent(builder::tlsTrustManagersProvider);
+        builder.tlsKeyManagersProvider(getTlsKeyManagersProvider(syncConfig.tlsKeyManagersProvider));
+        builder.tlsTrustManagersProvider(getTlsTrustManagersProvider(syncConfig.tlsTrustManagersProvider));
         return new RuntimeValue<>(builder);
     }
 }

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/TlsKeyManagersProviderConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/TlsKeyManagersProviderConfig.java
@@ -16,7 +16,7 @@ public class TlsKeyManagersProviderConfig {
      * * `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
      *                       `javax.net.ssl.keyStoreType` properties defined by the
      *                        https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
-     * * `file-store` - Provider that loads a the key store from a file.
+     * * `file-store` - Provider that loads the key store from a file.
      *
      * @asciidoclet
      */

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/TlsTrustManagersProviderConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/TlsTrustManagersProviderConfig.java
@@ -12,11 +12,11 @@ public class TlsTrustManagersProviderConfig {
      *
      * Available providers:
      *
-     * * `trust-all` - Use this provider to disable the validation of servers certificates and therefor turst all server certificates.
+     * * `trust-all` - Use this provider to disable the validation of servers certificates and therefore trust all server certificates.
      * * `system-property` - Provider checks the standard `javax.net.ssl.keyStore`, `javax.net.ssl.keyStorePassword`, and
      *                       `javax.net.ssl.keyStoreType` properties defined by the
      *                        https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[JSSE].
-     * * `file-store` - Provider that loads a the key store from a file.
+     * * `file-store` - Provider that loads the key store from a file.
      *
      * @asciidoclet
      */


### PR DESCRIPTION
Closes #237

Config provides a default value so a provider is always provided and returning Optional<> seems no more needed.

I fix some typos but don't know how to update the doc