### PR TITLE
Add support for TCP Keep-Alive

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientApacheTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientApacheTransportRecorder.java
@@ -29,6 +29,7 @@ public class AmazonClientApacheTransportRecorder extends AbstractAmazonClientTra
         builder.maxConnections(syncConfig.apache.maxConnections);
         builder.socketTimeout(syncConfig.socketTimeout);
         builder.useIdleConnectionReaper(syncConfig.apache.useIdleConnectionReaper);
+        builder.tcpKeepAlive(syncConfig.apache.tcpKeepAlive);
 
         if (syncConfig.apache.proxy.enabled && syncConfig.apache.proxy.endpoint.isPresent()) {
             ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder()

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
@@ -32,6 +32,7 @@ public class AmazonClientNettyTransportRecorder extends AbstractAmazonClientTran
         builder.protocol(asyncConfig.protocol);
         builder.readTimeout(asyncConfig.readTimeout);
         builder.writeTimeout(asyncConfig.writeTimeout);
+        builder.tcpKeepAlive(asyncConfig.tcpKeepAlive);
         asyncConfig.sslProvider.ifPresent(builder::sslProvider);
         builder.useIdleConnectionReaper(asyncConfig.useIdleConnectionReaper);
 

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/NettyHttpClientConfig.java
@@ -83,6 +83,12 @@ public class NettyHttpClientConfig {
     public boolean useIdleConnectionReaper;
 
     /**
+     * Configure whether to enable or disable TCP KeepAlive.
+     */
+    @ConfigItem(defaultValue = "false")
+    public Boolean tcpKeepAlive;
+
+    /**
      * The HTTP protocol to use.
      */
     @ConfigItem(defaultValue = "http1-1")

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
@@ -88,6 +88,12 @@ public class SyncHttpClientConfig {
         public boolean useIdleConnectionReaper;
 
         /**
+         * Configure whether to enable or disable TCP KeepAlive.
+         */
+        @ConfigItem(defaultValue = "false")
+        public Boolean tcpKeepAlive;
+
+        /**
          * HTTP proxy configuration
          */
         @ConfigItem

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.tcp-keep-alive[quarkus.cognito-user-pools.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.apache.proxy.enabled[quarkus.cognito-user-pools.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_ASYNC_CLIENT_USE_IDLE_CONNE
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tcp-keep-alive]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.tcp-keep-alive[quarkus.cognito-user-pools.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.protocol]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.async-client.protocol[quarkus.cognito-user-pools.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
@@ -759,6 +759,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.apache.tcp-keep-alive[quarkus.dynamodb.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.apache.proxy.enabled[quarkus.dynamodb.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1048,6 +1064,22 @@ Environment variable: `+++QUARKUS_DYNAMODB_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAP
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.tcp-keep-alive]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.tcp-keep-alive[quarkus.dynamodb.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.protocol]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.async-client.protocol[quarkus.dynamodb.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.apache.tcp-keep-alive[quarkus.iam.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-iam_quarkus.iam.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.apache.proxy.enabled[quarkus.iam.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_IAM_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.async-client.tcp-keep-alive]]`link:#quarkus-amazon-iam_quarkus.iam.async-client.tcp-keep-alive[quarkus.iam.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-iam_quarkus.iam.async-client.protocol]]`link:#quarkus-amazon-iam_quarkus.iam.async-client.protocol[quarkus.iam.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.apache.tcp-keep-alive[quarkus.kms.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-kms_quarkus.kms.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.apache.proxy.enabled[quarkus.kms.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_KMS_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.async-client.tcp-keep-alive]]`link:#quarkus-amazon-kms_quarkus.kms.async-client.tcp-keep-alive[quarkus.kms.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-kms_quarkus.kms.async-client.protocol]]`link:#quarkus-amazon-kms_quarkus.kms.async-client.protocol[quarkus.kms.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
@@ -873,6 +873,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.apache.tcp-keep-alive[quarkus.s3.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-s3_quarkus.s3.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.apache.proxy.enabled[quarkus.s3.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1162,6 +1178,22 @@ Environment variable: `+++QUARKUS_S3_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.async-client.tcp-keep-alive]]`link:#quarkus-amazon-s3_quarkus.s3.async-client.tcp-keep-alive[quarkus.s3.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-s3_quarkus.s3.async-client.protocol]]`link:#quarkus-amazon-s3_quarkus.s3.async-client.protocol[quarkus.s3.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.apache.tcp-keep-alive[quarkus.secretsmanager.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.apache.proxy.enabled[quarkus.secretsmanager.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_SECRETSMANAGER_ASYNC_CLIENT_USE_IDLE_CONNECTIO
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.tcp-keep-alive]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.tcp-keep-alive[quarkus.secretsmanager.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.protocol]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.async-client.protocol[quarkus.secretsmanager.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.apache.tcp-keep-alive[quarkus.ses.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-ses_quarkus.ses.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.apache.proxy.enabled[quarkus.ses.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_SES_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.async-client.tcp-keep-alive]]`link:#quarkus-amazon-ses_quarkus.ses.async-client.tcp-keep-alive[quarkus.ses.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-ses_quarkus.ses.async-client.protocol]]`link:#quarkus-amazon-ses_quarkus.ses.async-client.protocol[quarkus.ses.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.apache.tcp-keep-alive[quarkus.sns.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-sns_quarkus.sns.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.apache.proxy.enabled[quarkus.sns.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_SNS_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.async-client.tcp-keep-alive]]`link:#quarkus-amazon-sns_quarkus.sns.async-client.tcp-keep-alive[quarkus.sns.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-sns_quarkus.sns.async-client.protocol]]`link:#quarkus-amazon-sns_quarkus.sns.async-client.protocol[quarkus.sns.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.apache.tcp-keep-alive[quarkus.sqs.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.apache.proxy.enabled[quarkus.sqs.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_SQS_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.async-client.tcp-keep-alive]]`link:#quarkus-amazon-sqs_quarkus.sqs.async-client.tcp-keep-alive[quarkus.sqs.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-sqs_quarkus.sqs.async-client.protocol]]`link:#quarkus-amazon-sqs_quarkus.sqs.async-client.protocol[quarkus.sqs.async-client.protocol]`

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
@@ -743,6 +743,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.apache.tcp-keep-alive]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.apache.tcp-keep-alive[quarkus.ssm.sync-client.apache.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_APACHE_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.apache.proxy.enabled]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.apache.proxy.enabled[quarkus.ssm.sync-client.apache.proxy.enabled]`
 
 [.description]
@@ -1032,6 +1048,22 @@ Environment variable: `+++QUARKUS_SSM_ASYNC_CLIENT_USE_IDLE_CONNECTION_REAPER+++
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.async-client.tcp-keep-alive]]`link:#quarkus-amazon-ssm_quarkus.ssm.async-client.tcp-keep-alive[quarkus.ssm.async-client.tcp-keep-alive]`
+
+[.description]
+--
+Configure whether to enable or disable TCP KeepAlive.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_ASYNC_CLIENT_TCP_KEEP_ALIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_ASYNC_CLIENT_TCP_KEEP_ALIVE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
 
 
 a| [[quarkus-amazon-ssm_quarkus.ssm.async-client.protocol]]`link:#quarkus-amazon-ssm_quarkus.ssm.async-client.protocol[quarkus.ssm.async-client.protocol]`

--- a/dynamodb/deployment/src/test/resources/async-full-config.properties
+++ b/dynamodb/deployment/src/test/resources/async-full-config.properties
@@ -17,6 +17,7 @@ quarkus.dynamodb.async-client.connection-acquisition-timeout=0.01S
 quarkus.dynamodb.async-client.connection-time-to-live=0.01S
 quarkus.dynamodb.async-client.connection-max-idle-time=0.01S
 quarkus.dynamodb.async-client.use-idle-connection-reaper=false
+quarkus.dynamodb.async-client.tcp-keep-alive=true
 quarkus.dynamodb.async-client.protocol = http1-1
 quarkus.dynamodb.async-client.http2.max-streams = 10
 quarkus.dynamodb.async-client.http2.initial-window-size = 10

--- a/dynamodb/deployment/src/test/resources/sync-apache-full-config.properties
+++ b/dynamodb/deployment/src/test/resources/sync-apache-full-config.properties
@@ -20,6 +20,7 @@ quarkus.dynamodb.sync-client.apache.connection-time-to-live = 0.100S
 quarkus.dynamodb.sync-client.apache.max-connections = 10
 quarkus.dynamodb.sync-client.apache.expect-continue-enabled = true
 quarkus.dynamodb.sync-client.apache.use-idle-connection-reaper = true
+quarkus.dynamodb.sync-client.apache.tcp-keep-alive = true
 quarkus.dynamodb.sync-client.apache.proxy.enabled = true
 quarkus.dynamodb.sync-client.apache.proxy.endpoint = http://127.1.1.1
 quarkus.dynamodb.sync-client.apache.proxy.username = foo


### PR DESCRIPTION
Refs: https://github.com/quarkiverse/quarkus-amazon-services/issues/116

TCP KeepAlive is currently supported for apache and netty only.
For apache, I set the param in the apache specific conf.
For netty, its the only async implementation, so its on the async conf directly.
