### PR TITLE
Declare compatibility for localstack image substitute

### DIFF
--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
@@ -252,7 +252,8 @@ public class DevServicesLocalStackProcessor {
                 // LocalStack default values are not statically exposed
                 // create an instance just to get those value
                 LocalStackContainer defaultValueContainerNotStarted = new LocalStackContainer(
-                        DockerImageName.parse(localStackDevServicesBuildTimeConfig.imageName));
+                        DockerImageName.parse(localStackDevServicesBuildTimeConfig.imageName)
+                                .asCompatibleSubstituteFor("localstack/localstack"));
 
                 requestedServicesGroup.forEach(ds -> {
                     config.putAll(ds.getDevProvider().reuseLocalStack(new BorrowedLocalStackContainer() {
@@ -284,7 +285,8 @@ public class DevServicesLocalStackProcessor {
             }).orElseGet(
                     () -> {
                         LocalStackContainer container = new LocalStackContainer(
-                                DockerImageName.parse(localStackDevServicesBuildTimeConfig.imageName))
+                                DockerImageName.parse(localStackDevServicesBuildTimeConfig.imageName)
+                                        .asCompatibleSubstituteFor("localstack/localstack"))
                                 .withEnv(
                                         Stream.concat(
                                                 requestedServicesGroup.stream()


### PR DESCRIPTION
Using a private registry to bypass docker hub rate limits currently fails when using this extension.

Exception
```
java.lang.IllegalStateException: Failed to verify that image '<private-registry>/localstack/localstack:1.3.1' is a compatible substitute for 'localstack/localstack'. This generally means that you are trying to use an image that Testcontainers has not been designed to use. If this is deliberate, and if you are confident that the image is compatible, you should declare compatibility in code using the `asCompatibleSubstituteFor` method.
```