### PR TITLE
Pin localstack image version

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
@@ -12,7 +12,7 @@ public class LocalStackDevServicesBuildTimeConfig {
     /**
      * The LocalStack container image to use.
      */
-    @ConfigItem(defaultValue = "localstack/localstack")
+    @ConfigItem(defaultValue = "localstack/localstack:1.0.3")
     public String imageName;
 
     /**

--- a/docs/modules/ROOT/pages/amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/amazon-kms.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of KMS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:1.0.3
 ----
 This starts a KMS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/amazon-s3.adoc
@@ -40,7 +40,7 @@ You can also setup a local version of S3 manually, first start a LocalStack cont
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:0.11.5
+docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:1.0.3
 ----
 This starts a S3 instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of Secrets Manager manually, first start a L
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:1.0.3
 ----
 This starts a Secrets Manager instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/amazon-ses.adoc
@@ -36,7 +36,7 @@ You can also set up a local version of SES manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:1.0.3
 ----
 This starts a SES instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -39,7 +39,7 @@ You can also set up a local version of SNS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:0.11.1
+docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:1.0.3
 ----
 This starts a SNS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -40,7 +40,7 @@ You can also set up a local version of SQS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-sqs -p 4566:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-sqs -p 4566:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:1.0.3
 ----
 This starts a SQS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of SSM manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:0.11.1
+docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:1.0.3
 ----
 This starts a SSM instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/dev-services.adoc
+++ b/docs/modules/ROOT/pages/dev-services.adoc
@@ -24,11 +24,11 @@ Sharing is disabled by default in dev mode, and is always disabled in test mode.
 
 == Configuring the image
 
-Dev Services for Amazon Services uses the latest `localstack/localstack` image. You can configure the image and version using the `quarkus.aws.devservices.localstack.image-name` property:
+Dev Services for Amazon Services uses `localstack/localstack` image. You can configure the image and version using the `quarkus.aws.devservices.localstack.image-name` property:
 
 [source,properties]
 ----
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:0.13.1
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3
 ----
 
 == Specific configuration

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.http.test-timeout=1m
 
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:0.13.1
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3
 quarkus.aws.devservices.localstack.container-properties."START_WEB"=0
 quarkus.aws.devservices.localstack.additional-services.kinesis.enabled=true
 quarkus.aws.devservices.localstack.additional-services.redshift.enabled=true

--- a/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
+++ b/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
@@ -25,7 +25,7 @@ public class S3DevServicesTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0"),
+                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3"),
                             "application.properties"));
 
     @Test


### PR DESCRIPTION
Currently, the default container image version used for localstack is `latest`. This causes unexpected issues every now and then. To avoid such issues, pinning the version is required.

#### Why have I not used the latest version of localstack (1.3.1 - as of this writing)?
Few integration tests kept failing with localstack versions 1.3.1 down till 1.0.4. These integration tests were related to SSM. As far as I understood (not an SSM expert), those failures looked like issues on the localstack side. Also, if that is indeed an issue on our end, then we can pick that work in another PR.