### PR TITLE
Bump localstack version to 1.4.0.

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
@@ -12,7 +12,7 @@ public class LocalStackDevServicesBuildTimeConfig {
     /**
      * The LocalStack container image to use.
      */
-    @ConfigItem(defaultValue = "localstack/localstack:1.0.3")
+    @ConfigItem(defaultValue = "localstack/localstack:1.4.0")
     public String imageName;
 
     /**
@@ -28,7 +28,8 @@ public class LocalStackDevServicesBuildTimeConfig {
     public Optional<String> initScriptsFolder;
 
     /**
-     * Specific container log message to be waiting for localstack init scripts completion.
+     * Specific container log message to be waiting for localstack init scripts
+     * completion.
      */
     @ConfigItem
     public Optional<String> initCompletionMsg;

--- a/docs/modules/ROOT/pages/amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/amazon-kms.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of KMS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:1.0.3
+docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:1.4.0
 ----
 This starts a KMS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/amazon-s3.adoc
@@ -40,7 +40,7 @@ You can also setup a local version of S3 manually, first start a LocalStack cont
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:1.0.3
+docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:1.4.0
 ----
 This starts a S3 instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of Secrets Manager manually, first start a L
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:1.0.3
+docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:1.4.0
 ----
 This starts a Secrets Manager instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/amazon-ses.adoc
@@ -36,7 +36,7 @@ You can also set up a local version of SES manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:1.0.3
+docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:1.4.0
 ----
 This starts a SES instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -39,7 +39,7 @@ You can also set up a local version of SNS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:1.0.3
+docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:1.4.0
 ----
 This starts a SNS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -40,7 +40,7 @@ You can also set up a local version of SQS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-sqs -p 4566:4576 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:1.0.3
+docker run --rm --name local-sqs -p 4566:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:1.4.0
 ----
 This starts a SQS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of SSM manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:1.0.3
+docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:1.4.0
 ----
 This starts a SSM instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/dev-services.adoc
+++ b/docs/modules/ROOT/pages/dev-services.adoc
@@ -28,7 +28,7 @@ Dev Services for Amazon Services uses `localstack/localstack` image. You can con
 
 [source,properties]
 ----
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.4.0
 ----
 
 == Specific configuration

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.http.test-timeout=1m
 
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.4.0
 quarkus.aws.devservices.localstack.container-properties."START_WEB"=0
 quarkus.aws.devservices.localstack.additional-services.kinesis.enabled=true
 quarkus.aws.devservices.localstack.additional-services.redshift.enabled=true

--- a/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
+++ b/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
@@ -25,7 +25,7 @@ public class S3DevServicesTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.0.3"),
+                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:1.4.0"),
                             "application.properties"));
 
     @Test


### PR DESCRIPTION
Change localstack port to 4566 (new default). See examples they provided: https://docs.localstack.cloud/user-guide/aws/sqs/
Align it with quarkusio/quarkus-quickstarts PR which also use version 1.4.0 and container + local port 4566