### PR TITLE
Add conditional extension dependencies for Apache and Netty

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,6 +44,26 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-apache-client-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId> 
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-netty-client-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId> 
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-devservices-dynamodb</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/common/deployment-apache-client-internal/pom.xml
+++ b/common/deployment-apache-client-internal/pom.xml
@@ -8,8 +8,9 @@
         <version>999-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkus-amazon-common-deployment</artifactId>
-    <name>Quarkus - Amazon Services - Common - Deployment</name>
+    <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId>
+    <name>Quarkus - Amazon Services - Apache Client - Internal - Deployment</name>
+    <description>This module only exists to house quarkus-apache-httpclient as a conditional dependency</description>
 
     <dependencies>
         <dependency>
@@ -17,36 +18,12 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId> 
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId> 
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-common-deployment-spi</artifactId>
+            <artifactId>quarkus-amazon-apache-client-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-deployment</artifactId>
-        </dependency>
-        <!-- required by testcontainer localstack -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>${awssdk.v1.version}</version>
+            <artifactId>quarkus-apache-httpclient-deployment</artifactId>
         </dependency>
     </dependencies>
 

--- a/common/deployment-netty-client-internal/pom.xml
+++ b/common/deployment-netty-client-internal/pom.xml
@@ -8,8 +8,9 @@
         <version>999-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkus-amazon-common-deployment</artifactId>
-    <name>Quarkus - Amazon Services - Common - Deployment</name>
+    <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId>
+    <name>Quarkus - Amazon Services - Netty Client - Internal - Deployment</name>
+    <description>This module only exists to house quarkus-netty-httpclient as a conditional dependency</description>
 
     <dependencies>
         <dependency>
@@ -17,36 +18,12 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId> 
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId> 
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.amazonservices</groupId>
-            <artifactId>quarkus-amazon-common-deployment-spi</artifactId>
+            <artifactId>quarkus-amazon-netty-client-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-deployment</artifactId>
-        </dependency>
-        <!-- required by testcontainer localstack -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>${awssdk.v1.version}</version>
+            <artifactId>quarkus-netty-deployment</artifactId>
         </dependency>
     </dependencies>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -14,6 +14,10 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>runtime-apache-client-internal</module>
+        <module>deployment-apache-client-internal</module>
+        <module>runtime-netty-client-internal</module>
+        <module>deployment-netty-client-internal</module>
         <module>runtime</module>
         <module>deployment-spi</module>
         <module>deployment</module>

--- a/common/runtime-apache-client-internal/pom.xml
+++ b/common/runtime-apache-client-internal/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-common-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-apache-client-internal</artifactId>
+    <name>Quarkus - Amazon Services - Apache Client - Runtime - Internal</name>
+    <description>This module only exists to house quarkus-apache-httpclient as a conditional dependency</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apache-httpclient</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal> 
+                        </goals>
+                        <configuration>
+                        <dependencyCondition>
+                            <artifact>software.amazon.awssdk:apache-client</artifact> 
+                        </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/common/runtime-netty-client-internal/pom.xml
+++ b/common/runtime-netty-client-internal/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-common-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-netty-client-internal</artifactId>
+    <name>Quarkus - Amazon Services - Netty Client - Runtime - Internal</name>
+    <description>This module only exists to house quarkus-netty-httpclient as a conditional dependency</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal> 
+                        </goals>
+                        <configuration>
+                        <dependencyCondition>
+                            <artifact>software.amazon.awssdk:netty-nio-client</artifact> 
+                        </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -47,6 +47,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-netty-client-internal</artifactId> 
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
             <optional>true</optional>
@@ -54,6 +59,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-apache-client-internal</artifactId> 
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
@@ -183,10 +183,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 
@@ -272,10 +268,6 @@ And we need to add the Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/amazon-dynamodb.adoc
@@ -333,10 +333,6 @@ And add following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local DynamoDB instance, configure it as follows:
@@ -469,10 +465,6 @@ And add Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/amazon-kms.adoc
@@ -182,10 +182,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local KMS instance, configure it as follows:
@@ -285,10 +281,6 @@ And we need to add the Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/amazon-s3.adoc
@@ -327,10 +327,6 @@ And add following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 For asynchronous client refer to <<Going asynchronous>> for more information.
@@ -490,10 +486,6 @@ And we need to add the Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
@@ -204,10 +204,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local Secrets Manager instance, configure it as follows:
@@ -300,10 +296,6 @@ To enable the asynchronous client, we also need to add the Netty HTTP client dep
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/amazon-ses.adoc
@@ -174,10 +174,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local SES instance, configure it as follows:
@@ -266,10 +262,6 @@ And we need to add the Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -621,10 +621,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local SNS instance, configure it as follows:
@@ -856,10 +852,6 @@ And we need to add Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -294,10 +294,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local SQS instance, configure it as follows:
@@ -453,10 +449,6 @@ And we need to add the Netty HTTP client dependency to the `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -244,10 +244,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local SSM instance, configure it as follows:
@@ -350,10 +346,6 @@ To enable the asynchronous client, we also need to add the Netty HTTP client dep
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>netty-nio-client</artifactId>
-</dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-netty</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-sts.adoc
+++ b/docs/modules/ROOT/pages/amazon-sts.adoc
@@ -96,10 +96,6 @@ And add the following dependency to the application `pom.xml`:
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
 </dependency>
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-apache-httpclient</artifactId>
-</dependency>
 ----
 
 If you're going to use a local STS instance, configure it as follows:

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -77,20 +77,12 @@
             <artifactId>netty-nio-client</artifactId>
         </dependency>        
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-netty</artifactId>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -11,3 +11,5 @@ quarkus.s3.devservices.buckets=quarkus.test.bucket
 quarkus.dynamodb.interceptors=io.quarkus.it.amazon.dynamodb.DynamoDBModifyResponse
 quarkus.s3.interceptors=io.quarkus.it.amazon.s3.S3ModifyResponse
 quarkus.dynamodbenhanced.client-extensions=software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension,io.quarkus.it.amazon.dynamodb.enhanced.MyExtension
+
+quarkus.s3.sync-client.type=apache


### PR DESCRIPTION
This adds conditional extension dependencies to the common module, which allows for the automatic inclusion of the required Quarkus extensions for Netty and Apache clients.

With this change, developers won't need to manually add the Quarkus extensions for Netty and Apache, since they will be automatically included based on the project's use of the HTTP client implementation dependencies.