### PR TITLE
feat: use quarkus default thread pool

### DIFF
--- a/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
+++ b/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
@@ -160,6 +160,7 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
+++ b/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient;
@@ -142,7 +143,8 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -153,7 +155,7 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
                 CognitoIdentityProviderClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 CognitoIdentityProviderAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkus/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.cognitouserpools.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -48,7 +50,8 @@ public class CognitoUserPoolsRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         CognitoIdentityProviderAsyncClientBuilder builder = CognitoIdentityProviderAsyncClient.builder();
 
@@ -58,6 +61,9 @@ public class CognitoUserPoolsRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
@@ -26,6 +26,7 @@ import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.runtime.RuntimeValue;
@@ -192,7 +193,8 @@ abstract public class AbstractAmazonServiceProcessor {
             RuntimeValue<SdkPresigner.Builder> presignerBuilder,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
         String configName = configName();
 
         Optional<RuntimeValue<SdkHttpClient.Builder>> syncSdkHttpClientBuilder = amazonClientSyncTransports.stream()
@@ -219,7 +221,7 @@ abstract public class AbstractAmazonServiceProcessor {
 
         if (syncClientBuilder != null) {
             syncClientBuilder = recorder.configure(syncClientBuilder, awsConfigRuntime, sdkConfigRuntime,
-                    sdkBuildConfig, configName());
+                    sdkBuildConfig, executorBuildItem.getExecutorProxy(), configName());
             syntheticBeans.produce(SyntheticBeanBuildItem.configure(syncClientBuilderClass)
                     .setRuntimeInit()
                     .scope(ApplicationScoped.class)
@@ -229,7 +231,7 @@ abstract public class AbstractAmazonServiceProcessor {
         }
         if (asyncClientBuilder != null) {
             asyncClientBuilder = recorder.configure(asyncClientBuilder, awsConfigRuntime, sdkConfigRuntime,
-                    sdkBuildConfig, configName());
+                    sdkBuildConfig, executorBuildItem.getExecutorProxy(), configName());
             syntheticBeans.produce(SyntheticBeanBuildItem.configure(asyncClientBuilderClass)
                     .setRuntimeInit()
                     .scope(ApplicationScoped.class)

--- a/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
+++ b/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
@@ -148,7 +149,8 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -159,7 +161,7 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
                 DynamoDbClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 DynamoDbAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
+++ b/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
@@ -166,6 +166,7 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/dynamodb/runtime/src/main/java/io/quarkus/amazon/dynamodb/runtime/DynamodbRecorder.java
+++ b/dynamodb/runtime/src/main/java/io/quarkus/amazon/dynamodb/runtime/DynamodbRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.dynamodb.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -50,7 +52,8 @@ public class DynamodbRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         DynamoDbAsyncClientBuilder builder = DynamoDbAsyncClient.builder();
         builder.endpointDiscoveryEnabled(config.enableEndpointDiscovery);
@@ -61,6 +64,9 @@ public class DynamodbRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
+++ b/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.iam.IamAsyncClient;
@@ -139,7 +140,8 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -150,7 +152,7 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
                 IamClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 IamAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
+++ b/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
@@ -157,6 +157,7 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/iam/runtime/src/main/java/io/quarkus/amazon/iam/runtime/IamRecorder.java
+++ b/iam/runtime/src/main/java/io/quarkus/amazon/iam/runtime/IamRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.iam.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -48,7 +50,8 @@ public class IamRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         IamAsyncClientBuilder builder = IamAsyncClient.builder();
         if (transport != null) {
@@ -57,6 +60,9 @@ public class IamRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
+++ b/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.kms.KmsAsyncClient;
@@ -139,7 +140,8 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -150,7 +152,7 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
                 KmsClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 KmsAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
+++ b/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
@@ -157,6 +157,7 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/kms/runtime/src/main/java/io/quarkus/amazon/kms/runtime/KmsRecorder.java
+++ b/kms/runtime/src/main/java/io/quarkus/amazon/kms/runtime/KmsRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.kms.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -48,7 +50,8 @@ public class KmsRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         KmsAsyncClientBuilder builder = KmsAsyncClient.builder();
         if (transport != null) {
@@ -57,6 +60,9 @@ public class KmsRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -141,7 +142,8 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -152,7 +154,7 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
                 S3ClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 S3AsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 S3Presigner.Builder.class,
                 recorder.createPresignerBuilder(),
                 syntheticBeans,

--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
@@ -159,6 +159,7 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
                 recorder.createPresignerBuilder(),
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/s3/runtime/src/main/java/io/quarkus/amazon/s3/runtime/S3Recorder.java
+++ b/s3/runtime/src/main/java/io/quarkus/amazon/s3/runtime/S3Recorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.s3.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -54,7 +56,8 @@ public class S3Recorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         S3AsyncClientBuilder builder = S3AsyncClient.builder();
         configureS3Client(builder);
@@ -65,6 +68,9 @@ public class S3Recorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -19,7 +19,6 @@ import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerBuildTimeConfig;
 import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerClientProducer;
-import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerConfig;
 import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
@@ -28,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
@@ -98,12 +98,12 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupApacheSyncTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,
             AmazonClientApacheTransportRecorder transportRecorder,
-            SecretsManagerConfig runtimeConfig, BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
 
         createApacheSyncTransportBuilder(amazonClients,
                 transportRecorder,
                 buildTimeConfig.syncClient,
-                recorder.getSyncConfig(runtimeConfig),
+                recorder.getSyncConfig(),
                 syncTransports);
     }
 
@@ -111,12 +111,12 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,
             AmazonClientUrlConnectionTransportRecorder transportRecorder,
-            SecretsManagerConfig runtimeConfig, BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
 
         createUrlConnectionSyncTransportBuilder(amazonClients,
                 transportRecorder,
                 buildTimeConfig.syncClient,
-                recorder.getSyncConfig(runtimeConfig),
+                recorder.getSyncConfig(),
                 syncTransports);
     }
 
@@ -124,11 +124,11 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupNettyAsyncTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,
             AmazonClientNettyTransportRecorder transportRecorder,
-            SecretsManagerConfig runtimeConfig, BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports) {
+            BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports) {
 
         createNettyAsyncTransportBuilder(amazonClients,
                 transportRecorder,
-                recorder.getAsyncConfig(runtimeConfig),
+                recorder.getAsyncConfig(),
                 asyncTransports);
     }
 
@@ -136,23 +136,23 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SecretsManagerRecorder recorder,
             AmazonClientRecorder commonRecorder,
-            SecretsManagerConfig runtimeConfig,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
-                recorder.getAwsConfig(runtimeConfig),
-                recorder.getSdkConfig(runtimeConfig),
+                recorder.getAwsConfig(),
+                recorder.getSdkConfig(),
                 buildTimeConfig.sdk,
                 syncTransports,
                 asyncTransports,
                 SecretsManagerClientBuilder.class,
-                (syncTransport) -> recorder.createSyncBuilder(runtimeConfig, syncTransport),
+                (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 SecretsManagerAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(runtimeConfig, asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -157,6 +157,7 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
+++ b/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
@@ -159,6 +159,7 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
+++ b/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.ses.SesAsyncClient;
@@ -141,7 +142,8 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -152,7 +154,7 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
                 SesClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 SesAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/ses/runtime/src/main/java/io/quarkus/amazon/ses/runtime/SesRecorder.java
+++ b/ses/runtime/src/main/java/io/quarkus/amazon/ses/runtime/SesRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.ses.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -47,7 +49,8 @@ public class SesRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         SesAsyncClientBuilder builder = SesAsyncClient.builder();
         if (transport != null) {

--- a/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
+++ b/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
@@ -157,6 +157,7 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
+++ b/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
@@ -139,7 +140,8 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -150,7 +152,7 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
                 SnsClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 SnsAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/sns/runtime/src/main/java/io/quarkus/amazon/sns/runtime/SnsRecorder.java
+++ b/sns/runtime/src/main/java/io/quarkus/amazon/sns/runtime/SnsRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.sns.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -48,7 +50,8 @@ public class SnsRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         SnsAsyncClientBuilder builder = SnsAsyncClient.builder();
 
@@ -58,6 +61,9 @@ public class SnsRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
+++ b/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
@@ -139,7 +140,8 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
                 recorder.getAwsConfig(),
@@ -150,7 +152,7 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
                 SqsClientBuilder.class,
                 (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 SqsAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
+++ b/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
@@ -157,6 +157,7 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/sqs/runtime/src/main/java/io/quarkus/amazon/sqs/runtime/SqsRecorder.java
+++ b/sqs/runtime/src/main/java/io/quarkus/amazon/sqs/runtime/SqsRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.sqs.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -17,6 +19,7 @@ import software.amazon.awssdk.services.sqs.SqsClientBuilder;
 
 @Recorder
 public class SqsRecorder {
+
     final SqsConfig config;
 
     public SqsRecorder(SqsConfig config) {
@@ -48,7 +51,8 @@ public class SqsRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         SqsAsyncClientBuilder builder = SqsAsyncClient.builder();
 
@@ -58,6 +62,9 @@ public class SqsRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }

--- a/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
+++ b/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
@@ -157,6 +157,7 @@ public class SsmProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
+++ b/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
@@ -156,6 +156,7 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
                 null,
                 syntheticBeans,
                 clientSync,
-                clientAsync);
+                clientAsync,
+                executorBuildItem);
     }
 }

--- a/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
+++ b/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
@@ -19,7 +19,6 @@ import io.quarkus.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.sts.runtime.StsBuildTimeConfig;
 import io.quarkus.amazon.sts.runtime.StsClientProducer;
-import io.quarkus.amazon.sts.runtime.StsConfig;
 import io.quarkus.amazon.sts.runtime.StsRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
@@ -28,6 +27,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
@@ -97,13 +97,13 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonApacheHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupApacheSyncTransport(List<AmazonClientBuildItem> amazonClients, StsRecorder recorder,
-            AmazonClientApacheTransportRecorder transportRecorder, StsConfig runtimeConfig,
+            AmazonClientApacheTransportRecorder transportRecorder,
             BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
 
         createApacheSyncTransportBuilder(amazonClients,
                 transportRecorder,
                 buildTimeConfig.syncClient,
-                recorder.getSyncConfig(runtimeConfig),
+                recorder.getSyncConfig(),
                 syncTransports);
     }
 
@@ -111,47 +111,47 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients,
             StsRecorder recorder, AmazonClientUrlConnectionTransportRecorder transportRecorder,
-            StsConfig runtimeConfig,
             BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
 
         createUrlConnectionSyncTransportBuilder(amazonClients,
                 transportRecorder,
                 buildTimeConfig.syncClient,
-                recorder.getSyncConfig(runtimeConfig),
+                recorder.getSyncConfig(),
                 syncTransports);
     }
 
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonNettyHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupNettyAsyncTransport(List<AmazonClientBuildItem> amazonClients, StsRecorder recorder,
-            AmazonClientNettyTransportRecorder transportRecorder, StsConfig runtimeConfig,
+            AmazonClientNettyTransportRecorder transportRecorder,
             BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports) {
 
         createNettyAsyncTransportBuilder(amazonClients,
                 transportRecorder,
-                recorder.getAsyncConfig(runtimeConfig),
+                recorder.getAsyncConfig(),
                 asyncTransports);
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(StsRecorder recorder, AmazonClientRecorder commonRecorder,
-            StsConfig runtimeConfig, List<AmazonClientSyncTransportBuildItem> syncTransports,
+            List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync) {
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
         createClientBuilders(commonRecorder,
-                recorder.getAwsConfig(runtimeConfig),
-                recorder.getSdkConfig(runtimeConfig),
+                recorder.getAwsConfig(),
+                recorder.getSdkConfig(),
                 buildTimeConfig.sdk,
                 syncTransports,
                 asyncTransports,
                 StsClientBuilder.class,
-                (syncTransport) -> recorder.createSyncBuilder(runtimeConfig, syncTransport),
+                (syncTransport) -> recorder.createSyncBuilder(syncTransport),
                 StsAsyncClientBuilder.class,
-                (asyncTransport) -> recorder.createAsyncBuilder(runtimeConfig, asyncTransport),
+                (asyncTransport) -> recorder.createAsyncBuilder(asyncTransport, executorBuildItem.getExecutorProxy()),
                 null,
                 null,
                 syntheticBeans,

--- a/sts/runtime/src/main/java/io/quarkus/amazon/sts/runtime/StsRecorder.java
+++ b/sts/runtime/src/main/java/io/quarkus/amazon/sts/runtime/StsRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkus.amazon.sts.runtime;
 
+import java.util.concurrent.Executor;
+
 import io.quarkus.amazon.common.runtime.AwsConfig;
 import io.quarkus.amazon.common.runtime.NettyHttpClientConfig;
 import io.quarkus.amazon.common.runtime.SdkConfig;
@@ -18,24 +20,29 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 @Recorder
 public class StsRecorder {
 
-    public RuntimeValue<SyncHttpClientConfig> getSyncConfig(StsConfig config) {
+    final StsConfig config;
+
+    public StsRecorder(StsConfig config) {
+        this.config = config;
+    }
+
+    public RuntimeValue<SyncHttpClientConfig> getSyncConfig() {
         return new RuntimeValue<>(config.syncClient);
     }
 
-    public RuntimeValue<NettyHttpClientConfig> getAsyncConfig(StsConfig config) {
+    public RuntimeValue<NettyHttpClientConfig> getAsyncConfig() {
         return new RuntimeValue<>(config.asyncClient);
     }
 
-    public RuntimeValue<AwsConfig> getAwsConfig(StsConfig config) {
+    public RuntimeValue<AwsConfig> getAwsConfig() {
         return new RuntimeValue<>(config.aws);
     }
 
-    public RuntimeValue<SdkConfig> getSdkConfig(StsConfig config) {
+    public RuntimeValue<SdkConfig> getSdkConfig() {
         return new RuntimeValue<>(config.sdk);
     }
 
-    public RuntimeValue<AwsClientBuilder> createSyncBuilder(StsConfig config,
-            RuntimeValue<SdkHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createSyncBuilder(RuntimeValue<SdkHttpClient.Builder> transport) {
         StsClientBuilder builder = StsClient.builder();
         if (transport != null) {
             builder.httpClientBuilder(transport.getValue());
@@ -43,8 +50,8 @@ public class StsRecorder {
         return new RuntimeValue<>(builder);
     }
 
-    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(StsConfig config,
-            RuntimeValue<SdkAsyncHttpClient.Builder> transport) {
+    public RuntimeValue<AwsClientBuilder> createAsyncBuilder(RuntimeValue<SdkAsyncHttpClient.Builder> transport,
+            Executor executor) {
 
         StsAsyncClientBuilder builder = StsAsyncClient.builder();
         if (transport != null) {
@@ -53,6 +60,9 @@ public class StsRecorder {
         if (!config.asyncClient.advanced.useFutureCompletionThreadPool) {
             builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
                     .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run));
+        } else {
+            builder.asyncConfiguration(asyncConfigBuilder -> asyncConfigBuilder
+                    .advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, executor));
         }
         return new RuntimeValue<>(builder);
     }


### PR DESCRIPTION
By default, AWS SDK creates multiple ThreadPools per client instance, one for future completion executor and one for schedule executor service. This PR replaces this behavior and use quarkus default thread pool for all client instances and ThreadPool usages.