### PR TITLE
fix: move to sdk:graal-sdk over nativeimage:svm

### DIFF
--- a/dynamodb-enhanced/runtime/pom.xml
+++ b/dynamodb-enhanced/runtime/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sts/runtime/pom.xml
+++ b/sts/runtime/pom.xml
@@ -76,8 +76,8 @@
         </dependency>
         
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Caused by https://github.com/quarkusio/quarkus/pull/34145