### PR TITLE
Fix asciidoc warnings by using proper links

### DIFF
--- a/docs/modules/ROOT/pages/amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/amazon-dynamodb.adoc
@@ -170,7 +170,7 @@ public class Fruit {
 }
 ----
 
-TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on the xref:writing-native-applications-tips.adoc#registerForReflection[native application tips] page.
+TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on the https://quarkus.io/guides/writing-native-applications-tips#registerForReflection[native application tips] page.
 
 
 Nothing fancy. One important thing to note is that having a default constructor is required by the JSON serialization layer. The static `from` method creates a bean based on the `Map`

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -165,7 +165,7 @@ public class Quark {
 ----
 Then, create a `org.acme.sns.QuarksCannonSyncResource` that will provide an API to shoot quarks into the SNS topic via the SNS synchronous client.
 
-TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on  the xref:writing-native-applications-tips.adoc#registerForReflection[native application tips] page.
+TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on the https://quarkus.io/guides/writing-native-applications-tips#registerForReflection[native application tips] page.
 
 
 [source,java]

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -157,7 +157,7 @@ public class Quark {
 ----
 Then, create a `org.acme.sqs.QuarksCannonSyncResource` that will provide an API to shoot quarks into the SQS queue using the synchronous client.
 
-TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on  the xref:writing-native-applications-tips.adoc#registerForReflection[native application tips] page.
+TIP: The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on the https://quarkus.io/guides/writing-native-applications-tips#registerForReflection[native application tips] page.
 
 
 [source,java]


### PR DESCRIPTION
Proof of all warnings gone:
<img width="656" alt="image" src="https://github.com/quarkiverse/quarkus-amazon-services/assets/11942401/ea93a63d-bef7-4080-8376-79f956b3af14">

Proof of warnings before this PR:
<img width="1010" alt="image" src="https://github.com/quarkiverse/quarkus-amazon-services/assets/11942401/0e524294-eb85-46a5-a55e-81bcfa257fcd">

Note: I fixed only main branch because I noticed in other projects that maintainers want to do downmerge manually.