### PR TITLE
support explicitly disabling dev services for cognito user pools

### DIFF
--- a/devservices/cognito-user-pools/src/main/java/io/quarkus/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
+++ b/devservices/cognito-user-pools/src/main/java/io/quarkus/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
@@ -41,6 +41,13 @@ public class CognitoUserPoolsDevServicesProcessor {
             return devServices.toBuildItem();
         }
 
+        // explicitly disabled
+        if (!clientBuildTimeConfig.devservices().enabled().orElse(true)) {
+            log.debugf(
+                    "Not starting Dev Services for Amazon Services - cognito user pools, as it has been disabled in the config.");
+            return null;
+        }
+
         if (ConfigUtils.isPropertyPresent("quarkus.cognito-user-pools.endpoint-override")) {
             log.debugf(
                     "Not starting Dev Services for Amazon Services - cognito user pools, the quarkus.cognito-user-pools.endpoint-override is configured.");


### PR DESCRIPTION
Copied implementation from base class used by other services:

https://github.com/quarkiverse/quarkus-amazon-services/blob/4ac8b51fa5395994accea1a4230c57b5d597b18d/common/deployment-devservices-spi/src/main/java/io/quarkus/amazon/common/deployment/spi/AbstractDevServicesLocalStackProcessor.java#L27-L33

Addresses concern raised here: https://github.com/quarkusio/quarkus/issues/34801#issuecomment-1669665084