### PR TITLE
feat: bump default localstack from 2.3.0 to 3.0.1

### DIFF
--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
@@ -14,7 +14,7 @@ public interface LocalStackDevServicesBuildTimeConfig {
     /**
      * The LocalStack container image to use.
      */
-    @WithDefault(value = "localstack/localstack:2.3.0")
+    @WithDefault(value = "localstack/localstack:3.0.1")
     String imageName();
 
     /**

--- a/docs/modules/ROOT/pages/amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/amazon-kms.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of KMS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-kms --publish 4566:4599 -e SERVICES=kms -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a KMS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/amazon-s3.adoc
@@ -40,7 +40,7 @@ You can also setup a local version of S3 manually, first start a LocalStack cont
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:2.3.0
+docker run -it --publish 4566:4566 -e SERVICES=s3 -e START_WEB=0 localstack/localstack:3.0.1
 ----
 This starts a S3 instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of Secrets Manager manually, first start a L
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-secrets-manager --publish 4566:4584 -e SERVICES=secretsmanager -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a Secrets Manager instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/amazon-ses.adoc
@@ -36,7 +36,7 @@ You can also set up a local version of SES manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-ses -p 4566:4579 -e SERVICES=ses -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a SES instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -39,7 +39,7 @@ You can also set up a local version of SNS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:2.3.0
+docker run -it --publish 4566:4575 -e SERVICES=sns -e START_WEB=0 localstack/localstack:3.0.1
 ----
 This starts a SNS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -42,7 +42,7 @@ You can also set up a local version of SQS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-sqs -p 4566:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-sqs -p 4566:4566 -e SERVICES=sqs -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a SQS instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -37,7 +37,7 @@ You can also set up a local version of SSM manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-ssm --publish 4566:4583 -e SERVICES=ssm -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a SSM instance that is accessible on port `4566`.
 

--- a/docs/modules/ROOT/pages/amazon-sts.adoc
+++ b/docs/modules/ROOT/pages/amazon-sts.adoc
@@ -36,7 +36,7 @@ You can also set up a local version of STS manually, first start a LocalStack co
 
 [source,bash,subs="verbatim,attributes"]
 ----
-docker run --rm --name local-sts --publish 4592:4592 -e SERVICES=sts -e START_WEB=0 -d localstack/localstack:2.3.0
+docker run --rm --name local-sts --publish 4592:4592 -e SERVICES=sts -e START_WEB=0 -d localstack/localstack:3.0.1
 ----
 This starts a STS instance that is accessible on port `4592`.
 

--- a/docs/modules/ROOT/pages/dev-services.adoc
+++ b/docs/modules/ROOT/pages/dev-services.adoc
@@ -28,7 +28,7 @@ Dev Services for Amazon Services uses `localstack/localstack` image. You can con
 
 [source,properties]
 ----
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:2.3.0
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:3.0.1
 ----
 
 == Specific configuration

--- a/docs/modules/ROOT/pages/includes/quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config.adoc
@@ -24,7 +24,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_AWS_DEVSERVICES_LOCALSTACK_IMAGE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`localstack/localstack:2.3.0`
+|`localstack/localstack:3.0.1`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus.aws.devservices.localstack.init-scripts-folder]]`link:#quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus.aws.devservices.localstack.init-scripts-folder[quarkus.aws.devservices.localstack.init-scripts-folder]`

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.http.test-timeout=1m
 
-quarkus.aws.devservices.localstack.image-name=localstack/localstack:2.3.0
+quarkus.aws.devservices.localstack.image-name=localstack/localstack:3.0.1
 quarkus.aws.devservices.localstack.container-properties."START_WEB"=0
 quarkus.aws.devservices.localstack.additional-services.kinesis.enabled=true
 quarkus.aws.devservices.localstack.additional-services.redshift.enabled=true

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.5.1</quarkus.version>
-    <awssdk.version>2.21.17</awssdk.version>
+    <awssdk.version>2.21.24</awssdk.version>
     <awscrt.version>0.28.6</awscrt.version>
   </properties>
   <build>

--- a/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
+++ b/s3/deployment/src/test/java/io/quarkus/amazon/s3/deployment/S3DevServicesTest.java
@@ -25,7 +25,7 @@ public class S3DevServicesTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:2.3.0"),
+                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:3.0.1"),
                             "application.properties"));
 
     @Test

--- a/sqs/deployment/src/test/java/io/quarkus/amazon/sqs/deployment/SqsDevServicesWithoutQueueTest.java
+++ b/sqs/deployment/src/test/java/io/quarkus/amazon/sqs/deployment/SqsDevServicesWithoutQueueTest.java
@@ -21,7 +21,7 @@ class SqsDevServicesWithoutQueueTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:2.3.0"),
+                    .addAsResource(new StringAsset("quarkus.aws.devservices.localstack.image-name=localstack/localstack:3.0.1"),
                             "application.properties"));
 
     @Test


### PR DESCRIPTION
Starting from AWS SDK version [2.21.19](https://github.com/aws/aws-sdk-java/releases/tag/2.21.19), AWS updated the protocol in the SQS API, and it is not compatible with versions of LocalStack lower than 3.0.1.