### PR TITLE
feat: add opentelemetry instrumentation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,6 +28,11 @@
                 <version>${awscrt.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+                <version>${awsotel.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-crt</artifactId>
                 <version>${project.version}</version>
@@ -55,6 +60,16 @@
             <dependency>
                 <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-common-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-opentelemetry-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.amazonservices</groupId>
+                <artifactId>quarkus-amazon-opentelemetry-internal-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
+++ b/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
@@ -21,10 +21,12 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -156,7 +158,9 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(CognitoUserPoolsRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -164,8 +168,10 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/common/deployment-opentelemetry-internal/pom.xml
+++ b/common/deployment-opentelemetry-internal/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-common-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-opentelemetry-internal-deployment</artifactId>
+    <name>Quarkus - Amazon Services - Apache Client - Internal - Deployment</name>
+    <description>This module only exists to house opentelemetry-aws-sdk-2.2 as a conditional dependency</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-opentelemetry-internal</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/common/deployment/pom.xml
+++ b/common/deployment/pom.xml
@@ -25,6 +25,16 @@
             <artifactId>quarkus-amazon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-opentelemetry-internal-deployment</artifactId> 
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.amazonservices</groupId>
             <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId> 
             <optional>true</optional>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,12 +17,14 @@
         <module>runtime-apache-client-internal</module>
         <module>runtime-netty-client-internal</module>
         <module>runtime-crt-client-internal</module>
+        <module>runtime-opentelemetry-internal</module>
         <module>runtime</module>
         <module>deployment-devservices-spi</module>
         <module>deployment-spi</module>
         <module>deployment-apache-client-internal</module>
         <module>deployment-netty-client-internal</module>
         <module>deployment-crt-client-internal</module>
+        <module>deployment-opentelemetry-internal</module>
         <module>deployment</module>
     </modules>
 

--- a/common/runtime-opentelemetry-internal/pom.xml
+++ b/common/runtime-opentelemetry-internal/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-common-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-amazon-opentelemetry-internal</artifactId>
+    <name>Quarkus - Amazon Services - OpenTelemetry - Runtime - Internal</name>
+    <description>This module only exists to house opentelemetry-aws-sdk-2.2 as a conditional dependency</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal> 
+                        </goals>
+                        <configuration>
+                        <dependencyCondition>
+                            <artifact>io.quarkus:quarkus-opentelemetry</artifact> 
+                        </dependencyCondition>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -38,6 +38,16 @@
             <artifactId>auth</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-opentelemetry-internal</artifactId> 
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-client-spi</artifactId>
         </dependency>

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientOpenTelemetryRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientOpenTelemetryRecorder.java
@@ -1,0 +1,32 @@
+package io.quarkus.amazon.common.runtime;
+
+import java.util.function.Function;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+
+@Recorder
+public class AmazonClientOpenTelemetryRecorder {
+
+    public Function<SyntheticCreationalContext<AwsClientBuilder>, AwsClientBuilder> configure(
+            RuntimeValue<AwsClientBuilder> clientBuilder) {
+        return new Function<SyntheticCreationalContext<AwsClientBuilder>, AwsClientBuilder>() {
+            @Override
+            public AwsClientBuilder apply(SyntheticCreationalContext<AwsClientBuilder> context) {
+                AwsClientBuilder builder = clientBuilder.getValue();
+                OpenTelemetry openTelemetry = context.getInjectedReference(OpenTelemetry.class);
+
+                builder.overrideConfiguration(
+                        builder.overrideConfiguration().toBuilder()
+                                .addExecutionInterceptor(AwsSdkTelemetry.create(openTelemetry).newExecutionInterceptor())
+                                .build());
+
+                return builder;
+            }
+        };
+    }
+}

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SdkBuildTimeConfig.java
@@ -3,7 +3,9 @@ package io.quarkus.amazon.common.runtime;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithName;
 
 /**
  * AWS SDK specific configurations
@@ -21,4 +23,11 @@ public interface SdkBuildTimeConfig {
      * @see software.amazon.awssdk.core.interceptor.ExecutionInterceptor
      */
     Optional<List<String>> interceptors(); // cannot be classes as can be runtime initialized (e.g. XRay interceptor)
+
+    /**
+     * OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+     */
+    @WithName("telemetry.enabled")
+    @ConfigDocDefault("false")
+    Optional<Boolean> telemetry();
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.telemetry.enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.telemetry.enabled[quarkus.cognito-user-pools.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.type]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.type[quarkus.cognito-user-pools.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-dynamodb_quarkus.dynamodb.telemetry.enabled]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.telemetry.enabled[quarkus.dynamodb.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.type]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.type[quarkus.dynamodb.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-iam_quarkus.iam.telemetry.enabled]]`link:#quarkus-amazon-iam_quarkus.iam.telemetry.enabled[quarkus.iam.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-iam_quarkus.iam.sync-client.type]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.type[quarkus.iam.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-kms_quarkus.kms.telemetry.enabled]]`link:#quarkus-amazon-kms_quarkus.kms.telemetry.enabled[quarkus.kms.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-kms_quarkus.kms.sync-client.type]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.type[quarkus.kms.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-lambda.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-lambda.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-lambda_quarkus.lambda.telemetry.enabled]]`link:#quarkus-amazon-lambda_quarkus.lambda.telemetry.enabled[quarkus.lambda.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-lambda_quarkus.lambda.sync-client.type]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.type[quarkus.lambda.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-s3_quarkus.s3.telemetry.enabled]]`link:#quarkus-amazon-s3_quarkus.s3.telemetry.enabled[quarkus.s3.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-s3_quarkus.s3.sync-client.type]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.type[quarkus.s3.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.telemetry.enabled]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.telemetry.enabled[quarkus.secretsmanager.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.type]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.type[quarkus.secretsmanager.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-ses_quarkus.ses.telemetry.enabled]]`link:#quarkus-amazon-ses_quarkus.ses.telemetry.enabled[quarkus.ses.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-ses_quarkus.ses.sync-client.type]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.type[quarkus.ses.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sns_quarkus.sns.telemetry.enabled]]`link:#quarkus-amazon-sns_quarkus.sns.telemetry.enabled[quarkus.sns.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sns_quarkus.sns.sync-client.type]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.type[quarkus.sns.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sqs_quarkus.sqs.telemetry.enabled]]`link:#quarkus-amazon-sqs_quarkus.sqs.telemetry.enabled[quarkus.sqs.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sqs_quarkus.sqs.sync-client.type]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.type[quarkus.sqs.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-ssm_quarkus.ssm.telemetry.enabled]]`link:#quarkus-amazon-ssm_quarkus.ssm.telemetry.enabled[quarkus.ssm.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-ssm_quarkus.ssm.sync-client.type]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.type[quarkus.ssm.sync-client.type]`
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sts.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sts.adoc
@@ -29,6 +29,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sts_quarkus.sts.telemetry.enabled]]`link:#quarkus-amazon-sts_quarkus.sts.telemetry.enabled[quarkus.sts.telemetry.enabled]`
+
+
+[.description]
+--
+OpenTelemetry AWS SDK instrumentation will be enabled if the OpenTelemetry extension is present and this value is true.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_TELEMETRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_TELEMETRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-amazon-sts_quarkus.sts.sync-client.type]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.type[quarkus.sts.sync-client.type]`
 
 

--- a/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
+++ b/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.dynamodb.runtime.DynamodbBuildTimeConfig;
 import io.quarkus.amazon.dynamodb.runtime.DynamodbClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.dynamodb.runtime.DynamodbRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -162,7 +164,9 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(DynamodbRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -170,8 +174,10 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
+++ b/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.iam.runtime.IamBuildTimeConfig;
 import io.quarkus.amazon.iam.runtime.IamClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.iam.runtime.IamRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(IamRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
@@ -76,11 +80,20 @@
             <groupId>io.quarkiverse.amazonservices</groupId>
             <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -105,6 +118,7 @@
             <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/integration-tests/src/main/java/io/quarkus/it/amazon/opentelemetry/ExporterResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/amazon/opentelemetry/ExporterResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.amazon.opentelemetry;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+@Path("")
+public class ExporterResource {
+    @Inject
+    InMemorySpanExporter inMemorySpanExporter;
+
+    @GET
+    @Path("/export")
+    public List<SpanData> export() {
+        return inMemorySpanExporter.getFinishedSpanItems()
+                .stream()
+                .filter(sd -> !sd.getName().contains("export") && !sd.getName().contains("reset"))
+                .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/reset")
+    public Response reset() {
+        inMemorySpanExporter.reset();
+        return Response.ok().build();
+    }
+
+    @ApplicationScoped
+    static class InMemorySpanExporterProducer {
+        @Produces
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -36,3 +36,6 @@ quarkus.sns.async-client.type=${async-client.type}
 quarkus.sqs.async-client.type=${async-client.type}
 quarkus.ssm.async-client.type=${async-client.type}
 quarkus.sts.async-client.type=${async-client.type}
+
+
+quarkus.s3.telemetry.enabled=true

--- a/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonOpenTelemetryTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/amazon/AmazonOpenTelemetryTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.it.amazon;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+public class AmazonOpenTelemetryTest {
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        RestAssured.when().get("/test/reset").then().statusCode(HTTP_OK);
+        await().atMost(30, SECONDS).until(() -> {
+            // make sure spans are cleared
+            List<Map<String, Object>> spans = getSpans();
+            if (spans.size() > 0) {
+                RestAssured.when().get("/test/reset").then().statusCode(HTTP_OK);
+            }
+            return spans.size() == 0;
+        });
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return RestAssured.when().get("/test/export").body().as(new TypeRef<>() {
+        });
+    }
+
+    @Test
+    public void testOpenTelemetryAsync() {
+        RestAssured.when().get("/test/s3/async");
+
+        assertSpans();
+    }
+
+    @Test
+    public void testOpenTelemetryBlocking() {
+        RestAssured.when().get("/test/s3/blocking");
+
+        assertSpans();
+    }
+
+    private void assertSpans() {
+        Awaitility.await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            assertFalse(getSpans().isEmpty());
+
+            // Assert insert has been traced
+            boolean spanEmitted = false;
+            for (Map<String, Object> spanData : getSpans()) {
+                if (spanData.get("instrumentationLibraryInfo") instanceof Map) {
+                    final Map instrumentationLibraryInfo = (Map) spanData.get("instrumentationLibraryInfo");
+                    var name = instrumentationLibraryInfo.get("name");
+                    if ("io.opentelemetry.aws-sdk-2.2".equals(name)) {
+                        spanEmitted = true;
+                        break;
+                    }
+                }
+            }
+            assertTrue(spanEmitted, "aws sdk was not traced.");
+        });
+    }
+}

--- a/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
+++ b/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.kms.runtime.KmsBuildTimeConfig;
 import io.quarkus.amazon.kms.runtime.KmsClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.kms.runtime.KmsRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(KmsRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/LambdaProcessor.java
+++ b/lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/LambdaProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.lambda.runtime.LambdaBuildTimeConfig;
 import io.quarkus.amazon.lambda.runtime.LambdaConfig;
@@ -26,6 +27,7 @@ import io.quarkus.amazon.lambda.runtime.LambdaRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -170,16 +172,20 @@ public class LambdaProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(final LambdaRecorder recorder,
-            final AmazonClientCommonRecorder commonRecorder,
-            final List<AmazonClientSyncTransportBuildItem> syncTransports,
-            final List<AmazonClientAsyncTransportBuildItem> asyncTransports,
-            final BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            final BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
-            final BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
-            final ExecutorBuildItem executorBuildItem) {
+            Capabilities capabilities,
+            AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
+            List<AmazonClientSyncTransportBuildItem> syncTransports,
+            List<AmazonClientAsyncTransportBuildItem> asyncTransports,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            BuildProducer<AmazonClientSyncResultBuildItem> clientSync,
+            BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
+            ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <quarkus.version>3.6.3</quarkus.version>
     <awssdk.version>2.22.1</awssdk.version>
     <awscrt.version>0.29.2</awscrt.version>
+    <awsotel.version>1.32.0-alpha</awsotel.version>
   </properties>
   <build>
     <pluginManagement>

--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.s3.runtime.S3BuildTimeConfig;
 import io.quarkus.amazon.s3.runtime.S3ClientProducer;
@@ -26,6 +27,7 @@ import io.quarkus.amazon.s3.runtime.S3Recorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -155,7 +157,9 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(S3Recorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -163,8 +167,10 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerBuildTimeConfig;
 import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.secretsmanager.runtime.SecretsManagerRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SecretsManagerRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
+++ b/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.ses.runtime.SesBuildTimeConfig;
 import io.quarkus.amazon.ses.runtime.SesClientProducer;
@@ -26,6 +27,7 @@ import io.quarkus.amazon.ses.runtime.SesRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -154,7 +156,9 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SesRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             SesConfig runtimeConfig,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
@@ -163,8 +167,10 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
+++ b/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.sns.runtime.SnsBuildTimeConfig;
 import io.quarkus.amazon.sns.runtime.SnsClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.sns.runtime.SnsRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SnsRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
+++ b/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.sqs.runtime.SqsBuildTimeConfig;
 import io.quarkus.amazon.sqs.runtime.SqsClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.sqs.runtime.SqsRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SqsRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
+++ b/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.ssm.runtime.SsmBuildTimeConfig;
 import io.quarkus.amazon.ssm.runtime.SsmClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.ssm.runtime.SsmRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class SsmProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(SsmRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class SsmProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,

--- a/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
+++ b/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.amazon.common.runtime.AmazonClientApacheTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientAwsCrtTransportRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientCommonRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientNettyTransportRecorder;
+import io.quarkus.amazon.common.runtime.AmazonClientOpenTelemetryRecorder;
 import io.quarkus.amazon.common.runtime.AmazonClientUrlConnectionTransportRecorder;
 import io.quarkus.amazon.sts.runtime.StsBuildTimeConfig;
 import io.quarkus.amazon.sts.runtime.StsClientProducer;
@@ -25,6 +26,7 @@ import io.quarkus.amazon.sts.runtime.StsRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -153,7 +155,9 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createClientBuilders(StsRecorder recorder,
+            Capabilities capabilities,
             AmazonClientCommonRecorder commonRecorder,
+            AmazonClientOpenTelemetryRecorder otelRecorder,
             List<AmazonClientSyncTransportBuildItem> syncTransports,
             List<AmazonClientAsyncTransportBuildItem> asyncTransports,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
@@ -161,8 +165,10 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
             BuildProducer<AmazonClientAsyncResultBuildItem> clientAsync,
             ExecutorBuildItem executorBuildItem) {
 
-        createClientBuilders(recorder,
+        createClientBuilders(capabilities,
+                recorder,
                 commonRecorder,
+                otelRecorder,
                 buildTimeConfig,
                 syncTransports,
                 asyncTransports,


### PR DESCRIPTION
Fix #1049 

Adding the following dependency to a project will automatically include an interceptor with default `AwsSdkTelemetry` configuration in all generated clients that have opted into instrumentation. This is achieved by setting the configuration property `quarkus.<extension>.telemetry.enabled` to true.

```
<dependency>
    <groupId>io.quarkus</groupId>
    <artifactId>quarkus-opentelemetry</artifactId>
</dependency>
```