### PR TITLE
feat: add support for aws crt-based sync client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        alternative-client-implementation: ['true', 'false']
+        include:
+          - sync-client-type: "url"
+            async-client-type: "netty"
+          - sync-client-type: "apache"
+            async-client-type: "netty"
+          - sync-client-type: "aws-crt"
+            async-client-type: "aws-crt"
 
     steps:
       - uses: actions/checkout@v3
@@ -39,4 +45,4 @@ jobs:
           java-version: 17
           cache: maven
       - name: Build with Maven
-        run: ./mvnw -B formatter:validate verify --file pom.xml -Dnative -Dalternative-client-implementation=${{ matrix.alternative-client-implementation }}
+        run: ./mvnw -B formatter:validate verify --file pom.xml -Dnative -Dsync-client-type=${{ matrix.sync-client-type }} -Dasync-client-type=${{ matrix.async-client-type }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each extension provides configuration properties to configure the clients and wi
 * URL Connection HTTP client (default for synchronous call)
 * Apache HTTP Client
 * Netty HTTP client (default for asynchronous call)
-* AWS CRT-based HTTP client (native mode is experimental)
+* AWS CRT-based HTTP client (for both synchronous and asynchronous client)
 
 ## Compatibility
 

--- a/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
+++ b/cognito-user-pools/deployment/src/main/java/io/quarkus/amazon/cognitouserpools/deployment/CognitoUserPoolsProcessor.java
@@ -113,6 +113,19 @@ public class CognitoUserPoolsProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, CognitoUserPoolsRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients,

--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/AbstractAmazonServiceProcessor.java
@@ -141,6 +141,32 @@ abstract public class AbstractAmazonServiceProcessor {
         });
     }
 
+    protected void createAwsCrtSyncTransportBuilder(List<AmazonClientBuildItem> amazonClients,
+            AmazonClientAwsCrtTransportRecorder recorder,
+            SyncHttpClientBuildTimeConfig buildSyncConfig,
+            RuntimeValue<SyncHttpClientConfig> syncConfig,
+            BuildProducer<AmazonClientSyncTransportBuildItem> clientSyncTransports) {
+
+        Optional<AmazonClientBuildItem> matchingClientBuildItem = amazonClients.stream()
+                .filter(c -> c.getAwsClientName().equals(configName()))
+                .findAny();
+
+        matchingClientBuildItem.ifPresent(client -> {
+            if (!client.getSyncClassName().isPresent()) {
+                return;
+            }
+            if (buildSyncConfig.type() != SyncHttpClientBuildTimeConfig.SyncClientType.AWS_CRT) {
+                return;
+            }
+
+            clientSyncTransports.produce(
+                    new AmazonClientSyncTransportBuildItem(
+                            client.getAwsClientName(),
+                            client.getSyncClassName().get(),
+                            recorder.configureSync(configName(), syncConfig)));
+        });
+    }
+
     protected void createUrlConnectionSyncTransportBuilder(List<AmazonClientBuildItem> amazonClients,
             AmazonClientUrlConnectionTransportRecorder recorder,
             SyncHttpClientBuildTimeConfig buildSyncConfig,

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientAwsCrtTransportRecorder.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/AmazonClientAwsCrtTransportRecorder.java
@@ -2,8 +2,10 @@ package io.quarkus.amazon.common.runtime;
 
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 
 @Recorder
 public class AmazonClientAwsCrtTransportRecorder extends AbstractAmazonClientTransportRecorder {
@@ -43,6 +45,48 @@ public class AmazonClientAwsCrtTransportRecorder extends AbstractAmazonClientTra
 
         if (config.proxy().enabled()) {
             config.proxy().endpoint().ifPresent(uri -> validateProxyEndpoint(extension, uri, "async"));
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public RuntimeValue<SdkHttpClient.Builder> configureSync(String clientName,
+            RuntimeValue<SyncHttpClientConfig> syncConfigRuntime) {
+
+        AwsCrtHttpClient.Builder builder = AwsCrtHttpClient.builder();
+        SyncHttpClientConfig syncConfig = syncConfigRuntime.getValue();
+        validateAwsCrtClientConfig(clientName, syncConfig);
+
+        builder.connectionTimeout(syncConfig.connectionTimeout());
+        syncConfig.crt().connectionMaxIdleTime().ifPresent(builder::connectionMaxIdleTime);
+        syncConfig.crt().maxConcurrency().ifPresent(builder::maxConcurrency);
+
+        if (syncConfig.crt().proxy().enabled() && syncConfig.crt().proxy().endpoint().isPresent()) {
+            software.amazon.awssdk.http.crt.ProxyConfiguration.Builder proxyBuilder = software.amazon.awssdk.http.crt.ProxyConfiguration
+                    .builder().scheme(syncConfig.crt().proxy().endpoint().get().getScheme())
+                    .host(syncConfig.crt().proxy().endpoint().get().getHost());
+            if (syncConfig.crt().proxy().endpoint().get().getPort() != -1) {
+                proxyBuilder.port(syncConfig.crt().proxy().endpoint().get().getPort());
+            }
+            syncConfig.crt().proxy().username().ifPresent(proxyBuilder::username);
+            syncConfig.crt().proxy().password().ifPresent(proxyBuilder::password);
+
+            builder.proxyConfiguration(proxyBuilder.build());
+        }
+
+        return new RuntimeValue<>(builder);
+    }
+
+    private void validateAwsCrtClientConfig(String extension, SyncHttpClientConfig config) {
+        config.crt().maxConcurrency().ifPresent(maxConcurrency -> {
+            if (maxConcurrency <= 0) {
+                throw new RuntimeConfigurationError(
+                        String.format("quarkus.%s.sync-client.crt.max-concurrency may not be negative or zero.", extension));
+            }
+        });
+
+        if (config.crt().proxy().enabled()) {
+            config.crt().proxy().endpoint().ifPresent(uri -> validateProxyEndpoint(extension, uri, "sync"));
         }
     }
 }

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/CrtHttpClientConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/CrtHttpClientConfig.java
@@ -1,0 +1,63 @@
+package io.quarkus.amazon.common.runtime;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.configuration.DurationConverter;
+import io.smallrye.config.WithConverter;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface CrtHttpClientConfig {
+
+    /**
+     * The maximum amount of time that a connection should be allowed to remain open
+     * while idle.
+     */
+    @ConfigDocDefault("60S")
+    @WithConverter(DurationConverter.class)
+    Optional<Duration> connectionMaxIdleTime();
+
+    /**
+     * The maximum number of allowed concurrent requests.
+     */
+    @ConfigDocDefault("50")
+    Optional<Integer> maxConcurrency();
+
+    /**
+     * HTTP proxy configuration
+     */
+    HttpClientProxyConfiguration proxy();
+
+    @ConfigGroup
+    public interface HttpClientProxyConfiguration {
+
+        /**
+         * Enable HTTP proxy
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * The endpoint of the proxy server that the SDK should connect through.
+         * <p>
+         * Currently, the endpoint is limited to a host and port. Any other URI
+         * components will result in an exception being
+         * raised.
+         */
+        Optional<URI> endpoint();
+
+        /**
+         * The username to use when connecting through a proxy.
+         */
+        Optional<String> username();
+
+        /**
+         * The password to use when connecting through a proxy.
+         */
+        Optional<String> password();
+    }
+}

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientBuildTimeConfig.java
@@ -14,6 +14,7 @@ public interface SyncHttpClientBuildTimeConfig {
 
     public enum SyncClientType {
         URL,
-        APACHE
+        APACHE,
+        AWS_CRT
     }
 }

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/SyncHttpClientConfig.java
@@ -44,6 +44,12 @@ public interface SyncHttpClientConfig {
     @ConfigDocSection
     ApacheHttpClientConfig apache();
 
+    /**
+     * AWS CRT-based HTTP client specific configurations
+     */
+    @ConfigDocSection
+    CrtHttpClientConfig crt();
+
     @ConfigGroup
     public interface ApacheHttpClientConfig {
         /**

--- a/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/amazon-cognitouserpools.adoc
@@ -170,7 +170,7 @@ client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.cognito-user-pools.sync-client.type=apache
@@ -182,6 +182,21 @@ And add the following dependency to the application `pom.xml`:
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
+</dependency>
+----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.cognito-user-pools.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/amazon-dynamodb.adoc
@@ -326,7 +326,7 @@ If you want to use the Apache HTTP client instead, configure it as follows:
 quarkus.dynamodb.sync-client.type=apache
 ----
 
-And add following dependency to the application `pom.xml`:
+And add the following dependency to the application `pom.xml`:
 [source,xml]
 ----
 <dependency>
@@ -334,6 +334,22 @@ And add following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.dynamodb.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local DynamoDB instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-eventbridge.adoc
+++ b/docs/modules/ROOT/pages/amazon-eventbridge.adoc
@@ -81,20 +81,34 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.eventbridge.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>apache-client</artifactId>
+</dependency>
+----
+
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.eventbridge.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/amazon-kinesis.adoc
+++ b/docs/modules/ROOT/pages/amazon-kinesis.adoc
@@ -81,15 +81,13 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.kinesis.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
@@ -97,6 +95,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.kinesis.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local Kinesis instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/amazon-kms.adoc
@@ -169,7 +169,7 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.kms.sync-client.type=apache
@@ -183,6 +183,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.kms.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local KMS instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-lambda.adoc
+++ b/docs/modules/ROOT/pages/amazon-lambda.adoc
@@ -84,15 +84,13 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.lambda.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
@@ -100,6 +98,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.lambda.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local Lambda instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/amazon-s3.adoc
@@ -314,7 +314,7 @@ add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.s3.sync-client.type=apache
@@ -328,6 +328,23 @@ And add following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.s3.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
+
 
 For asynchronous client refer to <<Going asynchronous>> for more information.
 

--- a/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/amazon-secretsmanager.adoc
@@ -189,15 +189,13 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.secretsmanager.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
@@ -205,6 +203,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.secretsmanager.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local Secrets Manager instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/amazon-ses.adoc
@@ -161,7 +161,7 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.ses.sync-client.type=apache
@@ -175,6 +175,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.ses.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local SES instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-sfn.adoc
+++ b/docs/modules/ROOT/pages/amazon-sfn.adoc
@@ -115,7 +115,7 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.sfn.sync-client.type=apache
@@ -129,6 +129,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.sfn.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local SFN instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/amazon-sns.adoc
@@ -608,7 +608,7 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.sns.sync-client.type=apache
@@ -622,6 +622,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.sns.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local SNS instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/amazon-sqs.adoc
@@ -281,7 +281,7 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.sqs.sync-client.type=apache
@@ -295,6 +295,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.sqs.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local SQS instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -229,15 +229,13 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.ssm.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
@@ -245,6 +243,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.ssm.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local SSM instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/amazon-sts.adoc
+++ b/docs/modules/ROOT/pages/amazon-sts.adoc
@@ -81,15 +81,13 @@ you need to add a URL connection client dependency to the `pom.xml` file:
 </dependency>
 ----
 
-If you want to use Apache HTTP client instead, configure it as follows:
-
+If you want to use the Apache HTTP client instead, configure it as follows:
 [source,properties]
 ----
 quarkus.sts.sync-client.type=apache
 ----
 
 And add the following dependency to the application `pom.xml`:
-
 [source,xml]
 ----
 <dependency>
@@ -97,6 +95,22 @@ And add the following dependency to the application `pom.xml`:
     <artifactId>apache-client</artifactId>
 </dependency>
 ----
+
+If you want to use the AWS CRT-based HTTP client instead, configure it as follows:
+[source,properties]
+----
+quarkus.sts.sync-client.type=aws-crt
+----
+
+And add the following dependency to the application `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>aws-crt-client</artifactId>
+</dependency>
+----
+
 
 If you're going to use a local STS instance, configure it as follows:
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-cognitouserpools.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.connection-max-idle-time[quarkus.cognito-user-pools.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.max-concurrency[quarkus.cognito-user-pools.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.enabled[quarkus.cognito-user-pools.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.endpoint[quarkus.cognito-user-pools.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.username]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.username[quarkus.cognito-user-pools.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.password]]`link:#quarkus-amazon-cognitouserpools_quarkus.cognito-user-pools.sync-client.crt.proxy.password[quarkus.cognito-user-pools.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_COGNITO_USER_POOLS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-dynamodb.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1022,6 +1022,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.connection-max-idle-time[quarkus.dynamodb.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.max-concurrency[quarkus.dynamodb.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.enabled[quarkus.dynamodb.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.endpoint[quarkus.dynamodb.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.username]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.username[quarkus.dynamodb.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.password]]`link:#quarkus-amazon-dynamodb_quarkus.dynamodb.sync-client.crt.proxy.password[quarkus.dynamodb.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_DYNAMODB_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-eventbridge.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-eventbridge.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.connection-max-idle-time[quarkus.eventbridge.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.max-concurrency[quarkus.eventbridge.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.enabled[quarkus.eventbridge.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.endpoint[quarkus.eventbridge.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.username]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.username[quarkus.eventbridge.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.password]]`link:#quarkus-amazon-eventbridge_quarkus.eventbridge.sync-client.crt.proxy.password[quarkus.eventbridge.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EVENTBRIDGE_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-iam.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-iam_quarkus.iam.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.connection-max-idle-time[quarkus.iam.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.max-concurrency[quarkus.iam.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.enabled[quarkus.iam.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.endpoint[quarkus.iam.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.username]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.username[quarkus.iam.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.password]]`link:#quarkus-amazon-iam_quarkus.iam.sync-client.crt.proxy.password[quarkus.iam.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IAM_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-kinesis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-kinesis.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.connection-max-idle-time[quarkus.kinesis.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.max-concurrency[quarkus.kinesis.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.enabled[quarkus.kinesis.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.endpoint[quarkus.kinesis.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.username]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.username[quarkus.kinesis.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.password]]`link:#quarkus-amazon-kinesis_quarkus.kinesis.sync-client.crt.proxy.password[quarkus.kinesis.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KINESIS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-kms.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-kms_quarkus.kms.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.connection-max-idle-time[quarkus.kms.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.max-concurrency[quarkus.kms.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.enabled[quarkus.kms.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.endpoint[quarkus.kms.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.username]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.username[quarkus.kms.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.password]]`link:#quarkus-amazon-kms_quarkus.kms.sync-client.crt.proxy.password[quarkus.kms.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_KMS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-lambda.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-lambda.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.connection-max-idle-time[quarkus.lambda.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.max-concurrency[quarkus.lambda.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.enabled[quarkus.lambda.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.endpoint[quarkus.lambda.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.username]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.username[quarkus.lambda.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.password]]`link:#quarkus-amazon-lambda_quarkus.lambda.sync-client.crt.proxy.password[quarkus.lambda.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LAMBDA_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-s3.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1145,6 +1145,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-s3_quarkus.s3.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.connection-max-idle-time[quarkus.s3.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.max-concurrency[quarkus.s3.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.enabled[quarkus.s3.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.endpoint[quarkus.s3.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.username]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.username[quarkus.s3.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.password]]`link:#quarkus-amazon-s3_quarkus.s3.sync-client.crt.proxy.password[quarkus.s3.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_S3_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-secretsmanager.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.connection-max-idle-time[quarkus.secretsmanager.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.max-concurrency[quarkus.secretsmanager.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.enabled[quarkus.secretsmanager.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.endpoint[quarkus.secretsmanager.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.username]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.username[quarkus.secretsmanager.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.password]]`link:#quarkus-amazon-secretsmanager_quarkus.secretsmanager.sync-client.crt.proxy.password[quarkus.secretsmanager.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SECRETSMANAGER_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ses.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-ses_quarkus.ses.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.connection-max-idle-time[quarkus.ses.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.max-concurrency[quarkus.ses.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.enabled[quarkus.ses.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.endpoint[quarkus.ses.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.username]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.username[quarkus.ses.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.password]]`link:#quarkus-amazon-ses_quarkus.ses.sync-client.crt.proxy.password[quarkus.ses.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SES_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sfn.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sfn.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.connection-max-idle-time[quarkus.sfn.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.max-concurrency[quarkus.sfn.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.enabled[quarkus.sfn.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.endpoint[quarkus.sfn.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.username]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.username[quarkus.sfn.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.password]]`link:#quarkus-amazon-sfn_quarkus.sfn.sync-client.crt.proxy.password[quarkus.sfn.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SFN_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sns.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-sns_quarkus.sns.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.connection-max-idle-time[quarkus.sns.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.max-concurrency[quarkus.sns.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.enabled[quarkus.sns.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.endpoint[quarkus.sns.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.username]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.username[quarkus.sns.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.password]]`link:#quarkus-amazon-sns_quarkus.sns.sync-client.crt.proxy.password[quarkus.sns.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SNS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sqs.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1022,6 +1022,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.connection-max-idle-time[quarkus.sqs.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.max-concurrency[quarkus.sqs.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.enabled[quarkus.sqs.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.endpoint[quarkus.sqs.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.username]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.username[quarkus.sqs.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.password]]`link:#quarkus-amazon-sqs_quarkus.sqs.sync-client.crt.proxy.password[quarkus.sqs.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SQS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.connection-max-idle-time[quarkus.ssm.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.max-concurrency[quarkus.ssm.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.enabled[quarkus.ssm.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.endpoint[quarkus.ssm.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.username]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.username[quarkus.ssm.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.password]]`link:#quarkus-amazon-ssm_quarkus.ssm.sync-client.crt.proxy.password[quarkus.ssm.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-sts.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-sts.adoc
@@ -60,7 +60,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`url`, `apache` 
+`url`, `apache`, `aws-crt` 
 |`url`
 
 
@@ -1005,6 +1005,117 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_APACHE_PROXY_NON_PROXY_HOSTS+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
+|
+
+
+h|[[quarkus-amazon-sts_quarkus.sts.sync-client.crt-aws-crt-based-http-client-specific-configurations]]link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt-aws-crt-based-http-client-specific-configurations[AWS CRT-based HTTP client specific configurations]
+
+h|Type
+h|Default
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.connection-max-idle-time]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.connection-max-idle-time[quarkus.sts.sync-client.crt.connection-max-idle-time]`
+
+
+[.description]
+--
+The maximum amount of time that a connection should be allowed to remain open while idle.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_CONNECTION_MAX_IDLE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+|`60S`
+
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.max-concurrency]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.max-concurrency[quarkus.sts.sync-client.crt.max-concurrency]`
+
+
+[.description]
+--
+The maximum number of allowed concurrent requests.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_MAX_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`50`
+
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.enabled]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.enabled[quarkus.sts.sync-client.crt.proxy.enabled]`
+
+
+[.description]
+--
+Enable HTTP proxy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.endpoint]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.endpoint[quarkus.sts.sync-client.crt.proxy.endpoint]`
+
+
+[.description]
+--
+The endpoint of the proxy server that the SDK should connect through.
+
+Currently, the endpoint is limited to a host and port. Any other URI components will result in an exception being raised.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/net/URI.html[URI]
+ 
+|
+
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.username]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.username[quarkus.sts.sync-client.crt.proxy.username]`
+
+
+[.description]
+--
+The username to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.password]]`link:#quarkus-amazon-sts_quarkus.sts.sync-client.crt.proxy.password[quarkus.sts.sync-client.crt.proxy.password]`
+
+
+[.description]
+--
+The password to use when connecting through a proxy.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_STS_SYNC_CLIENT_CRT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string 
 |
 
 

--- a/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
+++ b/dynamodb/deployment/src/main/java/io/quarkus/amazon/dynamodb/deployment/DynamodbProcessor.java
@@ -121,6 +121,19 @@ public class DynamodbProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, DynamodbRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, DynamodbRecorder recorder,

--- a/eventbridge/deployment/src/main/java/io/quarkus/amazon/eventbridge/deployment/EventBridgeProcessor.java
+++ b/eventbridge/deployment/src/main/java/io/quarkus/amazon/eventbridge/deployment/EventBridgeProcessor.java
@@ -112,6 +112,19 @@ public class EventBridgeProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, EventBridgeRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, EventBridgeRecorder recorder,

--- a/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
+++ b/iam/deployment/src/main/java/io/quarkus/amazon/iam/deployment/IamProcessor.java
@@ -112,6 +112,19 @@ public class IamProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, IamRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, IamRecorder recorder,

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -169,41 +169,14 @@
 
     <profiles>
         <profile>
-            <id>default-client-implementation</id>
+            <id>sync-client-type-apache</id>
             <activation>
                 <property>
-                  <name>alternative-client-implementation</name>
-                  <value>!true</value>
+                  <name>sync-client-type</name>
+                  <value>apache</value>
                 </property>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>netty-nio-client</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>url-connection-client</artifactId>
-                </dependency>
-            </dependencies>
-            <properties>
-                <sync-client.type>url</sync-client.type>
-                <async-client.type>netty</async-client.type>
-            </properties>
-        </profile>
-        <profile>
-            <id>alternative-client-implementation</id>
-            <activation>
-                <property>
-                  <name>alternative-client-implementation</name>
-                  <value>true</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>aws-crt-client</artifactId>
-                </dependency>
                 <dependency>
                     <groupId>software.amazon.awssdk</groupId>
                     <artifactId>apache-client</artifactId>
@@ -211,7 +184,112 @@
             </dependencies>
             <properties>
                 <sync-client.type>apache</sync-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>sync-client-type-url</id>
+            <activation>
+                <property>
+                  <name>sync-client-type</name>
+                  <value>url</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>url-connection-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <sync-client.type>url</sync-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>sync-client-type-aws-crt</id>
+            <activation>
+                <property>
+                  <name>sync-client-type</name>
+                  <value>aws-crt</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>aws-crt-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <sync-client.type>aws-crt</sync-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>async-client-type-netty</id>
+            <activation>
+                <property>
+                  <name>async-client-type</name>
+                  <value>netty</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <async-client.type>netty</async-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>async-client-type-aws-crt</id>
+            <activation>
+                <property>
+                  <name>async-client-type</name>
+                  <value>aws-crt</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>aws-crt-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
                 <async-client.type>aws-crt</async-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>sync-client-type-default-for-test</id>
+            <activation>
+                <property>
+                  <name>!sync-client-type</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>url-connection-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <sync-client.type>url</sync-client.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>async-client-type-default-for-test</id>
+            <activation>
+                <property>
+                  <name>!async-client-type</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <async-client.type>netty</async-client.type>
             </properties>
         </profile>
         <profile>

--- a/integration-tests/src/main/java/io/quarkus/it/amazon/kinesis/KinesisResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/amazon/kinesis/KinesisResource.java
@@ -33,9 +33,13 @@ public class KinesisResource {
     public String testSync() {
         LOG.info("Testing Sync Kinesis client");
 
-        kinesisClient.createStream(builder -> builder.streamName(STREAM_NAME + "sync").shardCount(1));
-        return kinesisClient.describeStream(builder -> builder.streamName(STREAM_NAME + "sync")).streamDescription()
-                .streamARN();
+        try {
+            kinesisClient.createStream(builder -> builder.streamName(STREAM_NAME + "sync").shardCount(1));
+            return kinesisClient.describeStream(builder -> builder.streamName(STREAM_NAME + "sync")).streamDescription()
+                    .streamARN();
+        } catch (UnsupportedOperationException ex) {
+            return ex.getMessage();
+        }
     }
 
     @GET

--- a/kinesis/deployment/src/main/java/io/quarkus/amazon/kinesis/deployment/KinesisProcessor.java
+++ b/kinesis/deployment/src/main/java/io/quarkus/amazon/kinesis/deployment/KinesisProcessor.java
@@ -114,6 +114,19 @@ public class KinesisProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, KinesisRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, KinesisRecorder recorder,

--- a/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
+++ b/kms/deployment/src/main/java/io/quarkus/amazon/kms/deployment/KmsProcessor.java
@@ -112,6 +112,19 @@ public class KmsProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, KmsRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, KmsRecorder recorder,

--- a/lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/LambdaProcessor.java
+++ b/lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/LambdaProcessor.java
@@ -121,6 +121,19 @@ public class LambdaProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, LambdaRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(

--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3Processor.java
@@ -114,6 +114,19 @@ public class S3Processor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, S3Recorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, S3Recorder recorder,

--- a/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
+++ b/secretsmanager/deployment/src/main/java/io/quarkus/amazon/secretsmanager/deployment/SecretsManagerProcessor.java
@@ -112,6 +112,19 @@ public class SecretsManagerProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SecretsManagerRecorder recorder,

--- a/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
+++ b/ses/deployment/src/main/java/io/quarkus/amazon/ses/deployment/SesProcessor.java
@@ -113,6 +113,19 @@ public class SesProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SesRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SesRecorder recorder,

--- a/sfn/deployment/src/main/java/io/quarkus/amazon/sfn/deployment/SfnProcessor.java
+++ b/sfn/deployment/src/main/java/io/quarkus/amazon/sfn/deployment/SfnProcessor.java
@@ -113,6 +113,19 @@ public class SfnProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SfnRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SfnRecorder recorder,

--- a/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
+++ b/sns/deployment/src/main/java/io/quarkus/amazon/sns/deployment/SnsProcessor.java
@@ -112,6 +112,19 @@ public class SnsProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SnsRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SnsRecorder recorder,

--- a/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
+++ b/sqs/deployment/src/main/java/io/quarkus/amazon/sqs/deployment/SqsProcessor.java
@@ -112,6 +112,19 @@ public class SqsProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SqsRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SqsRecorder recorder,

--- a/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
+++ b/ssm/deployment/src/main/java/io/quarkus/amazon/ssm/deployment/SsmProcessor.java
@@ -112,6 +112,19 @@ public class SsmProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, SsmRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, SsmRecorder recorder,

--- a/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
+++ b/sts/deployment/src/main/java/io/quarkus/amazon/sts/deployment/StsProcessor.java
@@ -112,6 +112,19 @@ public class StsProcessor extends AbstractAmazonServiceProcessor {
                 syncTransports);
     }
 
+    @BuildStep(onlyIf = AmazonHttpClients.IsAmazonAwsCrtHttpServicePresent.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void setupAwsCrtSyncTransport(List<AmazonClientBuildItem> amazonClients, StsRecorder recorder,
+            AmazonClientAwsCrtTransportRecorder transportRecorder,
+            BuildProducer<AmazonClientSyncTransportBuildItem> syncTransports) {
+
+        createAwsCrtSyncTransportBuilder(amazonClients,
+                transportRecorder,
+                buildTimeConfig.syncClient(),
+                recorder.getSyncConfig(),
+                syncTransports);
+    }
+
     @BuildStep(onlyIf = AmazonHttpClients.IsAmazonUrlConnectionHttpServicePresent.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setupUrlConnectionSyncTransport(List<AmazonClientBuildItem> amazonClients, StsRecorder recorder,


### PR DESCRIPTION
Fix #1074 

TODO:
- [x] add a crt config class for sync client
- [x] integration-tests with 3 sync client types
- [x] update documentation to mention a second alternative to url connection