### PR TITLE
feat: Devservice localstack port

### DIFF
--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
@@ -304,6 +304,10 @@ public class DevServicesLocalStackProcessor {
                                         .toArray(EnabledService[]::new))
                                 .withLabel(DEV_SERVICE_LABEL, devServiceName);
 
+                        localStackDevServicesBuildTimeConfig.port().ifPresent(port ->
+                            container.setPortBindings(Collections.singletonList("%s:%s".formatted(port, PORT)))
+                        );
+
                         localStackDevServicesBuildTimeConfig.initScriptsFolder().ifPresentOrElse(initScriptsFolder -> {
                             container.withFileSystemBind(initScriptsFolder, "/etc/localstack/init/ready.d", BindMode.READ_ONLY);
                         }, () -> localStackDevServicesBuildTimeConfig.initScriptsClasspath().ifPresent(resourcePath -> {

--- a/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
+++ b/common/deployment/src/main/java/io/quarkus/amazon/common/deployment/DevServicesLocalStackProcessor.java
@@ -304,9 +304,8 @@ public class DevServicesLocalStackProcessor {
                                         .toArray(EnabledService[]::new))
                                 .withLabel(DEV_SERVICE_LABEL, devServiceName);
 
-                        localStackDevServicesBuildTimeConfig.port().ifPresent(port ->
-                            container.setPortBindings(Collections.singletonList("%s:%s".formatted(port, PORT)))
-                        );
+                        localStackDevServicesBuildTimeConfig.port().ifPresent(
+                                port -> container.setPortBindings(Collections.singletonList("%s:%s".formatted(port, PORT))));
 
                         localStackDevServicesBuildTimeConfig.initScriptsFolder().ifPresentOrElse(initScriptsFolder -> {
                             container.withFileSystemBind(initScriptsFolder, "/etc/localstack/init/ready.d", BindMode.READ_ONLY);

--- a/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkus/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
@@ -43,4 +43,9 @@ public interface LocalStackDevServicesBuildTimeConfig {
      * you want is not covered by the extension
      */
     Map<String, DevServicesBuildTimeConfig> additionalServices();
+
+    /**
+     * Optional fixed port localstack will listen to.
+     */
+    Optional<Integer> port();
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config.adoc
@@ -78,6 +78,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus-aws-devservices-localstack-port]]`link:#quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus-aws-devservices-localstack-port[quarkus.aws.devservices.localstack.port]`
+
+
+[.description]
+--
+Optional fixed port localstack will listen to.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_DEVSERVICES_LOCALSTACK_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_AWS_DEVSERVICES_LOCALSTACK_PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus-aws-devservices-localstack-container-properties-container-properties]]`link:#quarkus-aws-devservices-localstack-local-stack-dev-services-build-time-config_quarkus-aws-devservices-localstack-container-properties-container-properties[quarkus.aws.devservices.localstack.container-properties]`
 
 


### PR DESCRIPTION
This update includes the ability to set an optional fixed port for LocalStack in Quarkus AWS DevServices.

closes https://github.com/quarkiverse/quarkus-amazon-services/issues/794