### PR TITLE
Add metadata to mark internal extensions as unlisted

### DIFF
--- a/common/runtime-apache-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/common/runtime-apache-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,4 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  unlisted: "true"

--- a/common/runtime-crt-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/common/runtime-crt-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,4 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  unlisted: "true"

--- a/common/runtime-netty-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/common/runtime-netty-client-internal/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,4 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  unlisted: "true"

--- a/common/runtime-opentelemetry-internal/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/common/runtime-opentelemetry-internal/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,4 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  unlisted: "true"


### PR DESCRIPTION
I notice that several extensions in this project are named as 'internal,' because they're wrappers for other extensions. 

<img width="1780" alt="image" src="https://github.com/quarkiverse/quarkus-amazon-services/assets/11509290/e738fb7a-5afd-478a-9b9e-30009ef08080">

There's an 'unlisted' metadata key that can be used to mark this kind of extension. It stops the extension from being listed in https://code.quarkus.io, and also stops it from showing in https://extensions.quarkus.io unless someone explicitly searches for it. (In this screencap, the left-most extension has been marked as internal, and is only showing because of the specific search.)

<img width="1814" alt="image" src="https://github.com/quarkiverse/quarkus-amazon-services/assets/11509290/48070060-7773-4faf-945d-738b660af9fa">

By the way, this is definitely a 'no accusation' PR - we don't really document `unlisted`, so there's no reason these extensions should have known to use it! There's also no harm in the `unlisted` key not being there, just a little bit of clutter.