### PR TITLE
fix: S3Crt async client injection issue

### DIFF
--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3CrtProcessor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3CrtProcessor.java
@@ -69,7 +69,9 @@ public class S3CrtProcessor {
 
             Type injectedType = getInjectedType(injectionPoint);
 
-            if (asyncClientName().equals(injectedType.name())) {
+            // Check if the injected type is S3AsyncClient
+            DotName s3AsyncClientName = DotName.createSimple(S3AsyncClient.class.getName());
+            if (s3AsyncClientName.equals(injectedType.name())) {
                 asyncClassName = Optional.of(asyncClientName());
             }
         }

--- a/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3CrtProcessor.java
+++ b/s3/deployment/src/main/java/io/quarkus/amazon/s3/deployment/S3CrtProcessor.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 public class S3CrtProcessor {
 
     public static final DotName S3CRT = DotName.createSimple(S3Crt.class);
+    private static final DotName S3_ASYNC_CLIENT = DotName.createSimple(S3AsyncClient.class.getName());
 
     S3BuildTimeConfig buildTimeConfig;
 
@@ -69,9 +70,7 @@ public class S3CrtProcessor {
 
             Type injectedType = getInjectedType(injectionPoint);
 
-            // Check if the injected type is S3AsyncClient
-            DotName s3AsyncClientName = DotName.createSimple(S3AsyncClient.class.getName());
-            if (s3AsyncClientName.equals(injectedType.name())) {
+            if (S3_ASYNC_CLIENT.equals(injectedType.name())) {
                 asyncClassName = Optional.of(asyncClientName());
             }
         }


### PR DESCRIPTION
Fix #1335 

The discover step was initially looking for all injection points, but during the filtering process, it incorrectly filtered by `S3CrtAsyncClient.class`. The injection point, however, expects to use `S3AsyncClient.class`.

```java
@Inject
@S3Crt
S3AsyncClient s3AsyncClient;
```