### PR TITLE
feat: pass container properties to moto container

### DIFF
--- a/devservices/cognito-user-pools/src/main/java/io/quarkus/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
+++ b/devservices/cognito-user-pools/src/main/java/io/quarkus/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
@@ -79,7 +79,8 @@ public class CognitoUserPoolsDevServicesProcessor {
 
         try {
             MotoContainer container = new MotoContainer(
-                    DockerImageName.parse(motoDevServicesBuildTimeConfig.imageName()));
+                    DockerImageName.parse(motoDevServicesBuildTimeConfig.imageName()))
+                    .withEnv(motoDevServicesBuildTimeConfig.containerProperties());
             container.start();
 
             compressor.close();


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-amazon-services/issues/1398

Passes container properties to the moto container.  

To achieve the reproducible user pool ids you need to define a property:

`quarkus.aws.devservices.moto.container-properties.MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY=HASH`


