### PR TITLE
Enforce quarkus-config-doc-maven-plugin version

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.15.0
+:quarkus-version: 3.15.1
 :quarkus-amazon-services-version: 3.0.0.alpha1
 :maven-version: 3.8.1+
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
         </plugin>
         <plugin>
           <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-config-doc-maven-plugin</artifactId>
+          <version>${quarkus.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.quarkus</groupId>
           <artifactId>quarkus-extension-maven-plugin</artifactId>
           <version>${quarkus.version}</version>
           <executions>


### PR DESCRIPTION
This is needed, otherwise Maven will just use the latest version released in Maven Central - which might not be compatible with the model generated by the quarkus-extension-processor.