### PR TITLE
Add description

### DIFF
--- a/crt/pom.xml
+++ b/crt/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>quarkus-amazon-crt-parent</artifactId>
     <name>Quarkus - Amazon Services - CRT</name>
+    <description>Allows interaction with the AWS CRT service</description>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
If a description isn't set the extension gets the inherited description from the parent pom:

<img width="232" alt="image" src="https://github.com/user-attachments/assets/61de12d4-1399-4531-b71a-3d3f36ab0ad6">
