### PR TITLE
feat: add support for custom moto docker image

### DIFF
--- a/devservices/cognito-user-pools/src/main/java/io/quarkiverse/amazon/devservices/cognitouserpools/MotoContainer.java
+++ b/devservices/cognito-user-pools/src/main/java/io/quarkiverse/amazon/devservices/cognitouserpools/MotoContainer.java
@@ -18,8 +18,7 @@ public class MotoContainer extends GenericContainer<MotoContainer> {
      * @param dockerImageName image name to use for Localstack
      */
     public MotoContainer(final DockerImageName dockerImageName) {
-        super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        super(dockerImageName.asCompatibleSubstituteFor(DEFAULT_IMAGE_NAME));
         waitingFor(Wait.forLogMessage("^ \\* Running on.*\\n", 1));
         withExposedPorts(PORT);
     }


### PR DESCRIPTION
Hello, currently `getmoto` gets its image from docker hub. Unfortunately I cannot rely on it and was instead trying to configure to use the [other official image](https://docs.getmoto.org/en/latest/docs/server_mode.html#run-using-docker) which is hosted on Github.

But while docker image is tagged as `motoserver/moto`, the github official image is tagged as `getmoto/motoserver`.

MotoContainer is using `assertCompatibleWith` which will fails namespace is different, unlike other docker images, for example [localstack](https://github.com/quarkiverse/quarkus-amazon-services/blob/564fa050b05e978517cf9c24f74134f1e1989a2b/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/DevServicesLocalStackProcessor.java#L260), which use `asCompatibleSubstituteFor`, allowing different namespace.