### PR TITLE
fix(common/runtime): missing static modifier

### DIFF
--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/CrtSubstitutions.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/CrtSubstitutions.java
@@ -127,7 +127,7 @@ public class CrtSubstitutions {
 
     @TargetClass(value = DefaultAwsCrtV4aHttpSigner.class, onlyWith = IsHttpAuthAwsCrtAbsent.class)
     @Delete
-    final class Delete_DefaultAwsCrtV4aHttpSigner {
+    static final class Delete_DefaultAwsCrtV4aHttpSigner {
     }
 
     @TargetClass(value = AwsV4aHttpSigner.class, onlyWith = IsHttpAuthAwsCrtAbsent.class)


### PR DESCRIPTION
Closes #1659 

on Delete_DefaultAwsCrtV4aHttpSigner requires an additional `static` modifier to the class for graalvm to build the native image

As all the inner classes declared in `CrtSubstitutions` are marked as `static` (and this one not), it should be marked as static and should not be breaking other code.
Ran tests after the change using the follow command:
```shell
mvn surefire-report:report -Daggregate=true -Dmaven.compiler.source=24 -Dmaven.compiler.target=24
```

But it seems hard to test graalvm build classes.