### PR TITLE
Add `<name>` to bom-internal

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>quarkus-amazon-services-bom-internal</artifactId>
+    <name>Quarkus - Amazon Services - BOM Internal</name>
     <packaging>pom</packaging>
 
     <dependencyManagement>


### PR DESCRIPTION
Because this is missing, the 3.6.0 release failed in  https://github.com/quarkiverse/quarkiverse-release/actions/runs/14974800965/job/42064280764