### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/devservices/cognito-user-pools/src/main/java/io/quarkiverse/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
+++ b/devservices/cognito-user-pools/src/main/java/io/quarkiverse/amazon/devservices/cognitouserpools/CognitoUserPoolsDevServicesProcessor.java
@@ -17,7 +17,7 @@ import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -28,7 +28,7 @@ public class CognitoUserPoolsDevServicesProcessor {
 
     static volatile RunningDevService devServices;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     DevServicesResultBuildItem setupCognitoUserPools(
             CognitoUserPoolsBuildTimeConfig clientBuildTimeConfig,
             MotoDevServicesBuildTimeConfig motoDevServicesBuildTimeConfig,


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in Quarkus 3.26 (we deprecated it in Quarkus 3.19).