### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/codegen/src/main/java/io/quarkiverse/amazon/codegen/poet/runtime/RecorderClass.java
+++ b/codegen/src/main/java/io/quarkiverse/amazon/codegen/poet/runtime/RecorderClass.java
@@ -51,15 +51,16 @@ public class RecorderClass implements ClassSpec {
 
     @Override
     public TypeSpec poetSpec() {
+        ParameterizedTypeName runtimeConfig = ParameterizedTypeName.get(ClassName.get(RuntimeValue.class), configClassName);
         TypeSpec.Builder builder = PoetUtils.createClassBuilder(recorderClassName)
                 .addModifiers(PUBLIC)
                 .addAnnotation(Recorder.class)
                 .superclass(AMAZON_CLIENT_RECORDER)
                 .addField(FieldSpec
-                        .builder(configClassName, "config")
+                        .builder(runtimeConfig, "config")
                         .addModifiers(FINAL).build())
                 .addMethod(MethodSpec.constructorBuilder().addModifiers(PUBLIC)
-                        .addParameter(configClassName, "config")
+                        .addParameter(runtimeConfig, "config")
                         .addStatement("this.config = config")
                         .build());
 
@@ -76,8 +77,9 @@ public class RecorderClass implements ClassSpec {
         return MethodSpec.methodBuilder("getAmazonClientsConfig")
                 .addAnnotation(Override.class)
                 .addModifiers(PUBLIC)
-                .returns(ParameterizedTypeName.get(ClassName.get(RuntimeValue.class), AMAZON_CLIENT_RUNTIME_CONFIG))
-                .addStatement("return new RuntimeValue<>(config)")
+                .returns(ParameterizedTypeName.get(ClassName.get(RuntimeValue.class),
+                        WildcardTypeName.subtypeOf(AMAZON_CLIENT_RUNTIME_CONFIG)))
+                .addStatement("return config")
                 .build();
     }
 
@@ -86,7 +88,7 @@ public class RecorderClass implements ClassSpec {
                 .addAnnotation(Override.class)
                 .addModifiers(PUBLIC)
                 .returns(ASYNC_HTTP_CLIENT_CONFIG)
-                .addStatement("return config.asyncClient()")
+                .addStatement("return config.getValue().asyncClient()")
                 .build();
     }
 
@@ -95,7 +97,7 @@ public class RecorderClass implements ClassSpec {
                 .addAnnotation(Override.class)
                 .addModifiers(PUBLIC)
                 .returns(SYNC_HTTP_CLIENT_CONFIG)
-                .addStatement("return config.syncClient()")
+                .addStatement("return config.getValue().syncClient()")
                 .build();
     }
 
@@ -109,7 +111,7 @@ public class RecorderClass implements ClassSpec {
 
         if (model.getEndpointOperation().isPresent()) {
             builder.addStatement(
-                    "config.enableEndpointDiscovery().ifPresent(enableEndpointDiscovery -> builder.endpointDiscoveryEnabled(enableEndpointDiscovery))");
+                    "config.getValue().enableEndpointDiscovery().ifPresent(enableEndpointDiscovery -> builder.endpointDiscoveryEnabled(enableEndpointDiscovery))");
         }
 
         return builder
@@ -127,7 +129,7 @@ public class RecorderClass implements ClassSpec {
 
         if (model.getEndpointOperation().isPresent()) {
             builder.addStatement(
-                    "config.enableEndpointDiscovery().ifPresent(enableEndpointDiscovery -> builder.endpointDiscoveryEnabled(enableEndpointDiscovery))");
+                    "config.getValue().enableEndpointDiscovery().ifPresent(enableEndpointDiscovery -> builder.endpointDiscoveryEnabled(enableEndpointDiscovery))");
         }
 
         return builder

--- a/codegen/src/test/resources/io/quarkiverse/amazon/codegen/poet/runtime/test-recorder-class.java
+++ b/codegen/src/test/resources/io/quarkiverse/amazon/codegen/poet/runtime/test-recorder-class.java
@@ -15,26 +15,26 @@ import software.amazon.awssdk.services.ecr.EcrClient;
 @Generated("io.quarkiverse.amazon:codegen")
 @Recorder
 public class EcrRecorder extends AmazonClientRecorder {
-    final EcrConfig config;
+    final RuntimeValue<EcrConfig> config;
 
-    public EcrRecorder(EcrConfig config) {
+    public EcrRecorder(RuntimeValue<EcrConfig> config) {
         this.config = config;
     }
 
 
     @Override
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
-        return new RuntimeValue<>(config);
+    public RuntimeValue<? extends HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
+        return config;
     }
 
     @Override
     public AsyncHttpClientConfig getAsyncClientConfig() {
-        return config.asyncClient();
+        return config.getValue().asyncClient();
     }
 
     @Override
     public SyncHttpClientConfig getSyncClientConfig() {
-        return config.syncClient();
+        return config.getValue().syncClient();
     }
 
     @Override

--- a/cognito-user-pools/runtime/src/main/java/io/quarkiverse/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
+++ b/cognito-user-pools/runtime/src/main/java/io/quarkiverse/amazon/cognitouserpools/runtime/CognitoUserPoolsRecorder.java
@@ -2,7 +2,6 @@ package io.quarkiverse.amazon.cognitouserpools.runtime;
 
 import io.quarkiverse.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkiverse.amazon.common.runtime.AsyncHttpClientConfig;
-import io.quarkiverse.amazon.common.runtime.HasAmazonClientRuntimeConfig;
 import io.quarkiverse.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -13,25 +12,25 @@ import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityPr
 
 @Recorder
 public class CognitoUserPoolsRecorder extends AmazonClientRecorder {
-    final CognitoUserPoolsConfig config;
+    final RuntimeValue<CognitoUserPoolsConfig> config;
 
-    public CognitoUserPoolsRecorder(CognitoUserPoolsConfig config) {
+    public CognitoUserPoolsRecorder(RuntimeValue<CognitoUserPoolsConfig> config) {
         this.config = config;
     }
 
     @Override
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
-        return new RuntimeValue<>(config);
+    public RuntimeValue<CognitoUserPoolsConfig> getAmazonClientsConfig() {
+        return config;
     }
 
     @Override
     public AsyncHttpClientConfig getAsyncClientConfig() {
-        return config.asyncClient();
+        return config.getValue().asyncClient();
     }
 
     @Override
     public SyncHttpClientConfig getSyncClientConfig() {
-        return config.syncClient();
+        return config.getValue().syncClient();
     }
 
     @Override

--- a/common/deployment-spi/src/main/java/io/quarkiverse/amazon/common/deployment/AmazonClientExtensionBuildItem.java
+++ b/common/deployment-spi/src/main/java/io/quarkiverse/amazon/common/deployment/AmazonClientExtensionBuildItem.java
@@ -31,7 +31,7 @@ public final class AmazonClientExtensionBuildItem extends MultiBuildItem {
     private final Class<?> presignerBuilderClass;
     private final RuntimeValue<SyncHttpClientConfig> syncConfig;
     private final RuntimeValue<AsyncHttpClientConfig> asyncConfig;
-    private final RuntimeValue<HasAmazonClientRuntimeConfig> amazonClientsConfig;
+    private final RuntimeValue<? extends HasAmazonClientRuntimeConfig> amazonClientsConfig;
 
     public AmazonClientExtensionBuildItem(
             String configName,
@@ -108,7 +108,7 @@ public final class AmazonClientExtensionBuildItem extends MultiBuildItem {
         return hasSdkBuildTimeConfig;
     }
 
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
+    public RuntimeValue<? extends HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
         return amazonClientsConfig;
     }
 

--- a/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/AmazonClientExtensionsProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/AmazonClientExtensionsProcessor.java
@@ -289,7 +289,7 @@ public class AmazonClientExtensionsProcessor {
             List<AmazonClientExtensionBuilderInstanceBuildItem> builderInstances,
             AmazonClientCommonRecorder recorder,
             AmazonClientBuilderRecorder builderRecorder,
-            RuntimeValue<HasAmazonClientRuntimeConfig> amazonClientConfigRuntime,
+            RuntimeValue<? extends HasAmazonClientRuntimeConfig> amazonClientConfigRuntime,
             HasSdkBuildTimeConfig sdkBuildConfig,
             List<RequireAmazonClientInjectionBuildItem> amazonClientInjections,
             List<RequireAmazonTelemetryBuildItem> amazonRequireTelemtryClients,

--- a/common/runtime-spi/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientRecorder.java
+++ b/common/runtime-spi/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientRecorder.java
@@ -7,7 +7,7 @@ import software.amazon.awssdk.awscore.presigner.SdkPresigner;
 
 public abstract class AmazonClientRecorder {
 
-    public abstract RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig();
+    public abstract <T> RuntimeValue<? extends HasAmazonClientRuntimeConfig> getAmazonClientsConfig();
 
     public abstract AsyncHttpClientConfig getAsyncClientConfig();
 

--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientCommonRecorder.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientCommonRecorder.java
@@ -32,7 +32,8 @@ public class AmazonClientCommonRecorder {
     private static final Log LOG = LogFactory.getLog(AmazonClientCommonRecorder.class);
 
     public RuntimeValue<AwsClientBuilder> configure(RuntimeValue<? extends AwsClientBuilder> clientBuilder,
-            RuntimeValue<HasAmazonClientRuntimeConfig> amazonClientConfigRuntime, HasSdkBuildTimeConfig sdkBuildTimeConfig,
+            RuntimeValue<? extends HasAmazonClientRuntimeConfig> amazonClientConfigRuntime,
+            HasSdkBuildTimeConfig sdkBuildTimeConfig,
             ScheduledExecutorService scheduledExecutorService, String awsServiceName, String clientName) {
         AwsClientBuilder builder = clientBuilder.getValue();
 
@@ -103,7 +104,7 @@ public class AmazonClientCommonRecorder {
 
     public RuntimeValue<SdkPresigner.Builder> configurePresigner(
             RuntimeValue<? extends SdkPresigner.Builder> clientBuilder,
-            RuntimeValue<HasAmazonClientRuntimeConfig> amazonClientConfigRuntime,
+            RuntimeValue<? extends HasAmazonClientRuntimeConfig> amazonClientConfigRuntime,
             String awsServiceName, String clientName) {
         SdkPresigner.Builder builder = clientBuilder.getValue();
 

--- a/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3CrtRecorder.java
+++ b/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3CrtRecorder.java
@@ -21,9 +21,9 @@ import software.amazon.awssdk.utils.StringUtils;
 @Recorder
 public class S3CrtRecorder {
 
-    final S3Config config;
+    final RuntimeValue<S3Config> config;
 
-    public S3CrtRecorder(S3Config config) {
+    public S3CrtRecorder(RuntimeValue<S3Config> config) {
         this.config = config;
     }
 
@@ -36,19 +36,19 @@ public class S3CrtRecorder {
 
     private void configureS3Client(S3CrtAsyncClientBuilder builder, String awsServiceName) {
         builder
-                .accelerate(config.accelerateMode())
-                .checksumValidationEnabled(config.checksumValidation())
-                .crossRegionAccessEnabled(config.useArnRegionEnabled())
-                .forcePathStyle(config.pathStyleAccess());
+                .accelerate(config.getValue().accelerateMode())
+                .checksumValidationEnabled(config.getValue().checksumValidation())
+                .crossRegionAccessEnabled(config.getValue().useArnRegionEnabled())
+                .forcePathStyle(config.getValue().pathStyleAccess());
 
-        config.crtClient().initialReadBufferSizeInBytes().ifPresent(builder::initialReadBufferSizeInBytes);
-        config.crtClient().maxConcurrency().ifPresent(builder::maxConcurrency);
-        config.crtClient().minimumPartSizeInBytes().ifPresent(builder::minimumPartSizeInBytes);
-        config.crtClient().targetThroughputInGbps().ifPresent(builder::targetThroughputInGbps);
-        config.crtClient().maxNativeMemoryLimitInBytes().ifPresent(builder::maxNativeMemoryLimitInBytes);
+        config.getValue().crtClient().initialReadBufferSizeInBytes().ifPresent(builder::initialReadBufferSizeInBytes);
+        config.getValue().crtClient().maxConcurrency().ifPresent(builder::maxConcurrency);
+        config.getValue().crtClient().minimumPartSizeInBytes().ifPresent(builder::minimumPartSizeInBytes);
+        config.getValue().crtClient().targetThroughputInGbps().ifPresent(builder::targetThroughputInGbps);
+        config.getValue().crtClient().maxNativeMemoryLimitInBytes().ifPresent(builder::maxNativeMemoryLimitInBytes);
 
-        AwsConfig awsConfig = config.clients().get(ClientUtil.DEFAULT_CLIENT_NAME).aws();
-        SdkConfig sdkConfig = config.clients().get(ClientUtil.DEFAULT_CLIENT_NAME).sdk();
+        AwsConfig awsConfig = config.getValue().clients().get(ClientUtil.DEFAULT_CLIENT_NAME).aws();
+        SdkConfig sdkConfig = config.getValue().clients().get(ClientUtil.DEFAULT_CLIENT_NAME).sdk();
 
         awsConfig.region().ifPresent(builder::region);
         AwsCredentialsProvider credential = awsConfig.credentials().map(c -> c.type().create(c, "quarkus." + awsServiceName))

--- a/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3Recorder.java
+++ b/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3Recorder.java
@@ -2,7 +2,6 @@ package io.quarkiverse.amazon.s3.runtime;
 
 import io.quarkiverse.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkiverse.amazon.common.runtime.AsyncHttpClientConfig;
-import io.quarkiverse.amazon.common.runtime.HasAmazonClientRuntimeConfig;
 import io.quarkiverse.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -20,25 +19,25 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Recorder
 public class S3Recorder extends AmazonClientRecorder {
 
-    final S3Config config;
+    final RuntimeValue<S3Config> config;
 
-    public S3Recorder(S3Config config) {
+    public S3Recorder(RuntimeValue<S3Config> config) {
         this.config = config;
     }
 
     @Override
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
-        return new RuntimeValue<>(config);
+    public RuntimeValue<S3Config> getAmazonClientsConfig() {
+        return config;
     }
 
     @Override
     public AsyncHttpClientConfig getAsyncClientConfig() {
-        return config.asyncClient();
+        return config.getValue().asyncClient();
     }
 
     @Override
     public SyncHttpClientConfig getSyncClientConfig() {
-        return config.syncClient();
+        return config.getValue().syncClient();
     }
 
     @Override
@@ -60,24 +59,24 @@ public class S3Recorder extends AmazonClientRecorder {
     public RuntimeValue<SdkPresigner.Builder> createPresignerBuilder() {
         S3Presigner.Builder builder = S3Presigner.builder()
                 .serviceConfiguration(s3ConfigurationBuilder().build())
-                .dualstackEnabled(config.dualstack());
+                .dualstackEnabled(config.getValue().dualstack());
         return new RuntimeValue<>(builder);
     }
 
     private void configureS3Client(S3BaseClientBuilder builder) {
         builder
                 .serviceConfiguration(s3ConfigurationBuilder().build())
-                .dualstackEnabled(config.dualstack());
+                .dualstackEnabled(config.getValue().dualstack());
     }
 
     private S3Configuration.Builder s3ConfigurationBuilder() {
         S3Configuration.Builder s3ConfigBuilder = S3Configuration.builder()
-                .accelerateModeEnabled(config.accelerateMode())
-                .checksumValidationEnabled(config.checksumValidation())
-                .chunkedEncodingEnabled(config.chunkedEncoding())
-                .pathStyleAccessEnabled(config.pathStyleAccess())
-                .useArnRegionEnabled(config.useArnRegionEnabled());
-        config.profileName().ifPresent(s3ConfigBuilder::profileName);
+                .accelerateModeEnabled(config.getValue().accelerateMode())
+                .checksumValidationEnabled(config.getValue().checksumValidation())
+                .chunkedEncodingEnabled(config.getValue().chunkedEncoding())
+                .pathStyleAccessEnabled(config.getValue().pathStyleAccess())
+                .useArnRegionEnabled(config.getValue().useArnRegionEnabled());
+        config.getValue().profileName().ifPresent(s3ConfigBuilder::profileName);
         return s3ConfigBuilder;
     }
 }

--- a/scheduler/runtime/src/main/java/io/quarkiverse/amazon/scheduler/runtime/SchedulerRecorder.java
+++ b/scheduler/runtime/src/main/java/io/quarkiverse/amazon/scheduler/runtime/SchedulerRecorder.java
@@ -2,7 +2,6 @@ package io.quarkiverse.amazon.scheduler.runtime;
 
 import io.quarkiverse.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkiverse.amazon.common.runtime.AsyncHttpClientConfig;
-import io.quarkiverse.amazon.common.runtime.HasAmazonClientRuntimeConfig;
 import io.quarkiverse.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -14,25 +13,25 @@ import software.amazon.awssdk.services.scheduler.SchedulerClient;
 @Recorder
 public class SchedulerRecorder extends AmazonClientRecorder {
 
-    final SchedulerConfig config;
+    final RuntimeValue<SchedulerConfig> config;
 
-    public SchedulerRecorder(SchedulerConfig config) {
+    public SchedulerRecorder(RuntimeValue<SchedulerConfig> config) {
         this.config = config;
     }
 
     @Override
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
-        return new RuntimeValue<>(config);
+    public RuntimeValue<SchedulerConfig> getAmazonClientsConfig() {
+        return config;
     }
 
     @Override
     public AsyncHttpClientConfig getAsyncClientConfig() {
-        return config.asyncClient();
+        return config.getValue().asyncClient();
     }
 
     @Override
     public SyncHttpClientConfig getSyncClientConfig() {
-        return config.syncClient();
+        return config.getValue().syncClient();
     }
 
     @Override

--- a/sqs/runtime/src/main/java/io/quarkiverse/amazon/sqs/runtime/SqsRecorder.java
+++ b/sqs/runtime/src/main/java/io/quarkiverse/amazon/sqs/runtime/SqsRecorder.java
@@ -2,7 +2,6 @@ package io.quarkiverse.amazon.sqs.runtime;
 
 import io.quarkiverse.amazon.common.runtime.AmazonClientRecorder;
 import io.quarkiverse.amazon.common.runtime.AsyncHttpClientConfig;
-import io.quarkiverse.amazon.common.runtime.HasAmazonClientRuntimeConfig;
 import io.quarkiverse.amazon.common.runtime.SyncHttpClientConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -14,25 +13,25 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 @Recorder
 public class SqsRecorder extends AmazonClientRecorder {
 
-    final SqsConfig config;
+    final RuntimeValue<SqsConfig> config;
 
-    public SqsRecorder(SqsConfig config) {
+    public SqsRecorder(RuntimeValue<SqsConfig> config) {
         this.config = config;
     }
 
     @Override
-    public RuntimeValue<HasAmazonClientRuntimeConfig> getAmazonClientsConfig() {
-        return new RuntimeValue<>(config);
+    public RuntimeValue<SqsConfig> getAmazonClientsConfig() {
+        return config;
     }
 
     @Override
     public AsyncHttpClientConfig getAsyncClientConfig() {
-        return config.asyncClient();
+        return config.getValue().asyncClient();
     }
 
     @Override
     public SyncHttpClientConfig getSyncClientConfig() {
-        return config.syncClient();
+        return config.getValue().syncClient();
     }
 
     @Override


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder, wrapped in a `RuntimeValue`.