### PR TITLE
fix: use a recorder for DynamoDbTable beans

### DIFF
--- a/dynamodb-enhanced/deployment/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/deployment/DynamodbEnhancedProcessor.java
+++ b/dynamodb-enhanced/deployment/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/deployment/DynamodbEnhancedProcessor.java
@@ -29,7 +29,7 @@ import io.quarkiverse.amazon.common.deployment.AmazonClientSyncResultBuildItem;
 import io.quarkiverse.amazon.common.deployment.RequireAmazonClientInjectionBuildItem;
 import io.quarkiverse.amazon.dynamodb.enhanced.runtime.BeanTableSchemaSubstitutionImplementation;
 import io.quarkiverse.amazon.dynamodb.enhanced.runtime.DynamoDbEnhancedBuildTimeConfig;
-import io.quarkiverse.amazon.dynamodb.enhanced.runtime.DynamodbEnhancedClientRecorder;
+import io.quarkiverse.amazon.dynamodb.enhanced.runtime.DynamoDbEnhancedClientRecorder;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.processor.InjectionPointInfo;
@@ -112,7 +112,7 @@ public class DynamodbEnhancedProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void createClientBuilders(
-            DynamodbEnhancedClientRecorder recorder,
+            DynamoDbEnhancedClientRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> syntheticBean,
             List<AmazonClientSyncResultBuildItem> syncBuilder,
             List<AmazonClientAsyncResultBuildItem> asyncBuilder) {
@@ -183,7 +183,7 @@ public class DynamodbEnhancedProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     public void recordTableSchema(
             DynamoDbEnhancedBuildTimeConfig config,
-            DynamodbEnhancedClientRecorder recorder,
+            DynamoDbEnhancedClientRecorder recorder,
             List<DynamodbEnhancedBeanBuildItem> dynamodbEnhancedBeanBuildItems,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
 

--- a/dynamodb-enhanced/runtime/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/runtime/DynamoDbEnhancedClientRecorder.java
+++ b/dynamodb-enhanced/runtime/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/runtime/DynamoDbEnhancedClientRecorder.java
@@ -24,12 +24,12 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 @Recorder
-public class DynamodbEnhancedClientRecorder {
-    private static final Log LOG = LogFactory.getLog(DynamodbEnhancedClientRecorder.class);
+public class DynamoDbEnhancedClientRecorder {
+    private static final Log LOG = LogFactory.getLog(DynamoDbEnhancedClientRecorder.class);
 
     DynamoDbEnhancedBuildTimeConfig buildTimeConfig;
 
-    public DynamodbEnhancedClientRecorder(DynamoDbEnhancedBuildTimeConfig buildTimeConfig) {
+    public DynamoDbEnhancedClientRecorder(DynamoDbEnhancedBuildTimeConfig buildTimeConfig) {
         this.buildTimeConfig = buildTimeConfig;
     }
 

--- a/dynamodb-enhanced/runtime/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/runtime/DynamoDbEnhancedTableRecorder.java
+++ b/dynamodb-enhanced/runtime/src/main/java/io/quarkiverse/amazon/dynamodb/enhanced/runtime/DynamoDbEnhancedTableRecorder.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.amazon.dynamodb.enhanced.runtime;
+
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+
+@Recorder
+public class DynamoDbEnhancedTableRecorder {
+
+    public Function<SyntheticCreationalContext<DynamoDbTable<?>>, DynamoDbTable<?>> createDynamoDbTable() {
+        return new Function<SyntheticCreationalContext<DynamoDbTable<?>>, DynamoDbTable<?>>() {
+            @Override
+            public DynamoDbTable<?> apply(SyntheticCreationalContext<DynamoDbTable<?>> creationalContext) {
+
+                DynamoDbEnhancedClient dynamoEnhancedClient = creationalContext
+                        .getInjectedReference(DynamoDbEnhancedClient.class);
+                String beanClassName = creationalContext.getParams().get("beanClassName").toString();
+                String tableName = creationalContext.getParams().get("tableName").toString();
+                Class<?> beanClass;
+                try {
+                    beanClass = Thread.currentThread().getContextClassLoader().loadClass(beanClassName);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Failed to load class for DynamoDbTable: " + beanClassName, e);
+                }
+                TableSchema<?> tableSchema = TableSchema.fromClass(beanClass);
+                return dynamoEnhancedClient.table(tableName, tableSchema);
+            }
+        };
+    }
+
+    public Function<SyntheticCreationalContext<DynamoDbAsyncTable<?>>, DynamoDbAsyncTable<?>> createDynamoDbAsyncTable() {
+        return new Function<SyntheticCreationalContext<DynamoDbAsyncTable<?>>, DynamoDbAsyncTable<?>>() {
+            @Override
+            public DynamoDbAsyncTable<?> apply(SyntheticCreationalContext<DynamoDbAsyncTable<?>> creationalContext) {
+
+                DynamoDbEnhancedAsyncClient dynamoEnhancedClient = creationalContext
+                        .getInjectedReference(DynamoDbEnhancedAsyncClient.class);
+                String beanClassName = creationalContext.getParams().get("beanClassName").toString();
+                String tableName = creationalContext.getParams().get("tableName").toString();
+                Class<?> beanClass;
+                try {
+                    beanClass = Thread.currentThread().getContextClassLoader().loadClass(beanClassName);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Failed to load class for DynamoDbTable: " + beanClassName, e);
+                }
+                TableSchema<?> tableSchema = TableSchema.fromClass(beanClass);
+                return dynamoEnhancedClient.table(tableName, tableSchema);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This fix avoid using Gizmo bytecode generation and the incoming breaking change in quarkus ExtendedBeanConfigurator creator.