### PR TITLE
Delete `DefaultS3CrtAsyncClient$AttachHttpAttributesExecutionInterceptor` in native mode

### DIFF
--- a/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3CrtSubstitutions.java
+++ b/s3/runtime/src/main/java/io/quarkiverse/amazon/s3/runtime/S3CrtSubstitutions.java
@@ -46,6 +46,11 @@ public class S3CrtSubstitutions {
     static final class Delete_DefaultS3CrtAsyncClient {
     }
 
+    @TargetClass(className = "software.amazon.awssdk.services.s3.internal.crt.DefaultS3CrtAsyncClient$AttachHttpAttributesExecutionInterceptor", onlyWith = S3CrtSubstitutions.IsCrtAbsent.class)
+    @Delete
+    static final class Delete_DefaultS3CrtAsyncClient$AttachHttpAttributesExecutionInterceptor {
+    }
+
     @TargetClass(value = S3CrtAsyncClient.class, onlyWith = S3CrtSubstitutions.IsCrtAbsent.class)
     @Delete
     static final class Delete_S3CrtAsyncClient {


### PR DESCRIPTION
When building with Mandrel 25 `native-image` tries to compile
`software.amazon.awssdk.services.s3.internal.crt.DefaultS3CrtAsyncClient$AttachHttpAttributesExecutionInterceptor.afterMarshalling(Context$AfterMarshalling, ExecutionAttributes)`
which leads to a compilation error due to
`java.lang.ClassNotFoundException: software.amazon.awssdk.crt.s3.ResumeToken`

Fixes https://github.com/quarkiverse/quarkus-amazon-services/issues/1950
