### PR TITLE
fix: revert to a fixed LocalStack container image version

### DIFF
--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/LocalStackDevServicesBuildTimeConfig.java
@@ -14,7 +14,7 @@ public interface LocalStackDevServicesBuildTimeConfig {
     /**
      * The LocalStack container image to use.
      */
-    @WithDefault(value = "localstack/localstack:latest")
+    @WithDefault(value = "localstack/localstack:4.13")
     String imageName();
 
     /**


### PR DESCRIPTION
The latest version was required for releasing a version for quarkus 3.31 a few days earlier. We prefer to maintain a fixed version for build reproducibility, though users can still override the version if needed.