### PR TITLE
Fix #1859: AppConfigData/SSM as a ConfigSource

### DIFF
--- a/docs/modules/ROOT/pages/amazon-appconfigdata.adoc
+++ b/docs/modules/ROOT/pages/amazon-appconfigdata.adoc
@@ -41,15 +41,84 @@ public class AppConfigDataService {
     AppConfigDataClient appConfigDataClient;
 
     public void listApplications() {
-        GetLatestConfigurationResponse response = client.getLatestConfiguration(GetLatestConfigurationRequest.builder().build());
+        GetLatestConfigurationResponse response = appConfigDataClient.getLatestConfiguration(GetLatestConfigurationRequest.builder().build());
         // Handle response, e.g. iterate over response.items()
     }
 }
 ----
 
+== Using AWS AppConfig Data as a Quarkus Config Source
+
+In addition to injecting `AppConfigDataClient` / `AppConfigDataAsyncClient`, you can use the AWS AppConfig *Data* API as a configuration source.
+When enabled, Quarkus starts a configuration session for your hosted configuration, loads the document, and exposes its entries as MicroProfile configuration properties.
+The source then polls for updates on a fixed interval (unless you disable polling).
+
+=== Enable the Config Source
+
+Enable the config source by setting:
+
+[source,properties]
+----
+quarkus.appconfigdata.config.enabled=true
+----
+
+=== Application, environment, and configuration profile
+
+The config source calls `StartConfigurationSession` with the following identifiers (IDs or names, as accepted by AWS):
+
+[source,properties]
+----
+quarkus.appconfigdata.config.enabled=true
+
+quarkus.appconfigdata.config.application=my-application
+quarkus.appconfigdata.config.environment=production
+quarkus.appconfigdata.config.configuration-profile=my-profile
+----
+
+With these properties in place, you can read values like any other Quarkus configuration (for example via `@ConfigProperty` or `@ConfigMapping`), using the keys described below.
+
+=== Optional polling settings
+
+* `quarkus.appconfigdata.config.required-minimum-poll-interval-in-seconds` -- optional; sets the minimum interval between `GetLatestConfiguration` calls for the session, when required by your configuration profile.
+* `quarkus.appconfigdata.config.update-interval-minutes` -- interval between polls after the initial load (default: `5`). Set to `0` to fetch only once at startup and skip periodic polling.
+
+=== How configuration keys are exposed
+
+The hosted configuration body is parsed into a flat map of string keys and string values:
+
+* If the document is **JSON**, nested objects are turned into dotted keys (for example `featureFlags.newCheckoutFlow` with value `true`).
+* JSON **arrays** use index segments (for example `items[0].name`).
+* If the document is **Java properties** format, standard `key=value` entries are exposed using those keys.
+
+Boolean and numeric JSON values are exposed as strings (`true`, `false`, and the number's string form).
+
+=== Credentials, region, and endpoint
+
+The config source uses the same AppConfig Data client configuration as the rest of the extension (credentials provider chain, region, and optional endpoint override).
+This is useful for LocalStack or custom endpoints:
+
+[source,properties]
+----
+quarkus.appconfigdata.endpoint-override=http://localhost:4566
+quarkus.appconfigdata.aws.region=us-east-1
+quarkus.appconfigdata.aws.credentials.type=static
+quarkus.appconfigdata.aws.credentials.static-provider.access-key-id=test-key
+quarkus.appconfigdata.aws.credentials.static-provider.secret-access-key=test-secret
+
+quarkus.appconfigdata.config.enabled=true
+quarkus.appconfigdata.config.application=my-application
+quarkus.appconfigdata.config.environment=production
+quarkus.appconfigdata.config.configuration-profile=my-profile
+----
+
+=== Notes and limitations
+
+* The config source keeps an internal snapshot that is updated when polling succeeds; components that only read configuration at startup will not see later changes unless they observe configuration dynamically.
+* If identifiers are missing or AppConfig Data returns an error during session start or fetch, Quarkus logs the error and the config source may expose no entries from AppConfig for that attempt.
+
 == Configuration Reference
 
-include::./amazon-configure-clients.adoc[]
+include::./includes/quarkus-amazon-appconfigdata.adoc[]
 
 == Related Guides
 

--- a/docs/modules/ROOT/pages/amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/amazon-ssm.adoc
@@ -282,6 +282,80 @@ include::./amazon-credentials.adoc[]
 
 And the region from your AWS CLI profile will be used.
 
+== Using AWS Systems Manager Parameter Store as a Quarkus Config Source
+
+In addition to injecting `SsmClient` / `SsmAsyncClient`, you can load configuration values from Parameter Store as a MicroProfile config source.
+When enabled, Quarkus fetches parameters (by path and/or by explicit name), maps them to configuration keys, and optionally reloads on a fixed interval.
+
+=== Enable the Config Source
+
+[source,properties]
+----
+quarkus.ssm.config.enabled=true
+----
+
+You must also configure at least one of **path** or **names** (see below). If both are unset, the config source is not registered.
+
+=== Load parameters by path
+
+Use `GetParametersByPath` for every parameter under a hierarchy (for example `/myapp/prod/`):
+
+[source,properties]
+----
+quarkus.ssm.config.enabled=true
+quarkus.ssm.config.path=/myapp/prod/
+
+# Optional (defaults shown)
+quarkus.ssm.config.recursive=true
+quarkus.ssm.config.with-decryption=true
+----
+
+=== Load parameters by name
+
+List full parameter names (up to ten per AWS request; the extension batches larger lists automatically):
+
+[source,properties]
+----
+quarkus.ssm.config.enabled=true
+quarkus.ssm.config.names[0]=/myapp/prod/db/url
+quarkus.ssm.config.names[1]=/myapp/prod/db/user
+----
+
+You can combine `quarkus.ssm.config.path` and `quarkus.ssm.config.names`; keys from both are merged into one config source.
+
+=== Optional polling
+
+`quarkus.ssm.config.update-interval-minutes` controls how often parameters are re-fetched after startup (default: `5`). Set to `0` to load only once at startup.
+
+=== How configuration keys are exposed
+
+* The Parameter Store name is normalized into a key prefix: a leading `/` is removed and remaining `/` characters become `.` (for example `/myapp/prod/url` → `myapp.prod.url`).
+* If the parameter **value** is JSON (object or array), it is flattened to dotted keys and prefixed (same idea as the AppConfig Data config source).
+* If the value contains an **equals sign**, it is parsed as Java `Properties` text; each property key is appended under the normalized parameter prefix.
+* Otherwise the whole value is exposed as a single property using the normalized parameter name as the key.
+
+=== Credentials, region, and endpoint
+
+The config source uses the same SSM client configuration as the rest of the extension:
+
+[source,properties]
+----
+quarkus.ssm.endpoint-override=http://localhost:4566
+quarkus.ssm.aws.region=us-east-1
+quarkus.ssm.aws.credentials.type=static
+quarkus.ssm.aws.credentials.static-provider.access-key-id=test-key
+quarkus.ssm.aws.credentials.static-provider.secret-access-key=test-secret
+
+quarkus.ssm.config.enabled=true
+quarkus.ssm.config.path=/myapp/prod/
+----
+
+=== Notes and limitations
+
+* The config source keeps an internal snapshot that is updated when a scheduled reload succeeds; components that only bind configuration at startup may not observe later changes.
+* If a reload fails, Quarkus logs the error and the previous snapshot (if any) is left in place.
+* `GetParameters` returns an `invalidParameters` list for names that do not exist; those names are logged at warn level.
+
 == Next steps
 
 === Packaging

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-appconfigdata.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-appconfigdata.adoc
@@ -204,6 +204,136 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-enabled]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-enabled[`+++quarkus.appconfigdata.config.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the AWS AppConfig Data ConfigSource (`quarkus.appconfigdata.config`).
+
+When disabled, no configuration values are loaded from AppConfig Data.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-application]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-application[`+++quarkus.appconfigdata.config.application+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.application+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig application ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_APPLICATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_APPLICATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-environment]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-environment[`+++quarkus.appconfigdata.config.environment+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.environment+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig environment ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_ENVIRONMENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_ENVIRONMENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-configuration-profile]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-configuration-profile[`+++quarkus.appconfigdata.config.configuration-profile+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.configuration-profile+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig configuration profile ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_CONFIGURATION_PROFILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_CONFIGURATION_PROFILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-required-minimum-poll-interval-in-seconds]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-required-minimum-poll-interval-in-seconds[`+++quarkus.appconfigdata.config.required-minimum-poll-interval-in-seconds+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.required-minimum-poll-interval-in-seconds+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional minimum interval between `GetLatestConfiguration` calls for the session.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_REQUIRED_MINIMUM_POLL_INTERVAL_IN_SECONDS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_REQUIRED_MINIMUM_POLL_INTERVAL_IN_SECONDS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-update-interval-minutes]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-update-interval-minutes[`+++quarkus.appconfigdata.config.update-interval-minutes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.update-interval-minutes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Interval in minutes between polling for configuration updates after the initial fetch.
+
+Set to `0` to disable periodic polling (only the initial load runs).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_UPDATE_INTERVAL_MINUTES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_UPDATE_INTERVAL_MINUTES+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 h|[[quarkus-amazon-appconfigdata_section_quarkus-appconfigdata]] [.section-name.section-level0]##link:#quarkus-amazon-appconfigdata_section_quarkus-appconfigdata[AWS SDK client configurations]##
 h|Type
 h|Default

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-appconfigdata_quarkus.appconfigdata.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-appconfigdata_quarkus.appconfigdata.adoc
@@ -204,6 +204,136 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-enabled]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-enabled[`+++quarkus.appconfigdata.config.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the AWS AppConfig Data ConfigSource (`quarkus.appconfigdata.config`).
+
+When disabled, no configuration values are loaded from AppConfig Data.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-application]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-application[`+++quarkus.appconfigdata.config.application+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.application+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig application ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_APPLICATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_APPLICATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-environment]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-environment[`+++quarkus.appconfigdata.config.environment+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.environment+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig environment ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_ENVIRONMENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_ENVIRONMENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-configuration-profile]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-configuration-profile[`+++quarkus.appconfigdata.config.configuration-profile+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.configuration-profile+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+AppConfig configuration profile ID or name for `software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_CONFIGURATION_PROFILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_CONFIGURATION_PROFILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-required-minimum-poll-interval-in-seconds]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-required-minimum-poll-interval-in-seconds[`+++quarkus.appconfigdata.config.required-minimum-poll-interval-in-seconds+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.required-minimum-poll-interval-in-seconds+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional minimum interval between `GetLatestConfiguration` calls for the session.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_REQUIRED_MINIMUM_POLL_INTERVAL_IN_SECONDS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_REQUIRED_MINIMUM_POLL_INTERVAL_IN_SECONDS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-update-interval-minutes]] [.property-path]##link:#quarkus-amazon-appconfigdata_quarkus-appconfigdata-config-update-interval-minutes[`+++quarkus.appconfigdata.config.update-interval-minutes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.appconfigdata.config.update-interval-minutes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Interval in minutes between polling for configuration updates after the initial fetch.
+
+Set to `0` to disable periodic polling (only the initial load runs).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_APPCONFIGDATA_CONFIG_UPDATE_INTERVAL_MINUTES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_APPCONFIGDATA_CONFIG_UPDATE_INTERVAL_MINUTES+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 h|[[quarkus-amazon-appconfigdata_section_quarkus-appconfigdata]] [.section-name.section-level0]##link:#quarkus-amazon-appconfigdata_section_quarkus-appconfigdata[AWS SDK client configurations]##
 h|Type
 h|Default

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm.adoc
@@ -204,6 +204,134 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-enabled]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-enabled[`+++quarkus.ssm.config.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the AWS Systems Manager Parameter Store ConfigSource (`quarkus.ssm.config`).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-path]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-path[`+++quarkus.ssm.config.path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Parameter Store path passed to `software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest`. When set, all parameters under this path are loaded (subject to `recursive()`).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-names]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-names[`+++quarkus.ssm.config.names+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.names+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Individual parameter names (full paths, for example `/myapp/prod/db/url`) passed to `software.amazon.awssdk.services.ssm.model.GetParametersRequest`. Batched in groups of ten per AWS limit.
+
+You can combine this with `path()`; the merged result is exposed as configuration keys.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_NAMES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_NAMES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-recursive]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-recursive[`+++quarkus.ssm.config.recursive+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.recursive+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When using `path()`, whether to load parameters in sub-paths recursively.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_RECURSIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_RECURSIVE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-with-decryption]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-with-decryption[`+++quarkus.ssm.config.with-decryption+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.with-decryption+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to decrypt `SecureString` parameters when fetching values.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_WITH_DECRYPTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_WITH_DECRYPTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-update-interval-minutes]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-update-interval-minutes[`+++quarkus.ssm.config.update-interval-minutes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.update-interval-minutes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Interval in minutes between reloads after the initial fetch. Set to `0` to fetch only once at startup.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_UPDATE_INTERVAL_MINUTES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_UPDATE_INTERVAL_MINUTES+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 h|[[quarkus-amazon-ssm_section_quarkus-ssm]] [.section-name.section-level0]##link:#quarkus-amazon-ssm_section_quarkus-ssm[AWS SDK client configurations]##
 h|Type
 h|Default

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm_quarkus.ssm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon-ssm_quarkus.ssm.adoc
@@ -204,6 +204,134 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-enabled]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-enabled[`+++quarkus.ssm.config.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the AWS Systems Manager Parameter Store ConfigSource (`quarkus.ssm.config`).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-path]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-path[`+++quarkus.ssm.config.path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Parameter Store path passed to `software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest`. When set, all parameters under this path are loaded (subject to `recursive()`).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-names]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-names[`+++quarkus.ssm.config.names+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.names+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Individual parameter names (full paths, for example `/myapp/prod/db/url`) passed to `software.amazon.awssdk.services.ssm.model.GetParametersRequest`. Batched in groups of ten per AWS limit.
+
+You can combine this with `path()`; the merged result is exposed as configuration keys.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_NAMES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_NAMES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-recursive]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-recursive[`+++quarkus.ssm.config.recursive+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.recursive+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When using `path()`, whether to load parameters in sub-paths recursively.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_RECURSIVE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_RECURSIVE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-with-decryption]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-with-decryption[`+++quarkus.ssm.config.with-decryption+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.with-decryption+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to decrypt `SecureString` parameters when fetching values.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_WITH_DECRYPTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_WITH_DECRYPTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-amazon-ssm_quarkus-ssm-config-update-interval-minutes]] [.property-path]##link:#quarkus-amazon-ssm_quarkus-ssm-config-update-interval-minutes[`+++quarkus.ssm.config.update-interval-minutes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.ssm.config.update-interval-minutes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Interval in minutes between reloads after the initial fetch. Set to `0` to fetch only once at startup.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_SSM_CONFIG_UPDATE_INTERVAL_MINUTES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_SSM_CONFIG_UPDATE_INTERVAL_MINUTES+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 h|[[quarkus-amazon-ssm_section_quarkus-ssm]] [.section-name.section-level0]##link:#quarkus-amazon-ssm_section_quarkus-ssm[AWS SDK client configurations]##
 h|Type
 h|Default

--- a/services/appconfigdata/deployment/src/main/java/io/quarkiverse/amazon/appconfigdata/deployment/AppConfigDataConfigSourceProcessor.java
+++ b/services/appconfigdata/deployment/src/main/java/io/quarkiverse/amazon/appconfigdata/deployment/AppConfigDataConfigSourceProcessor.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.amazon.appconfigdata.deployment;
+
+import io.quarkiverse.amazon.appconfigdata.runtime.AppConfigDataConfigSourceBuilder;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
+
+public class AppConfigDataConfigSourceProcessor {
+
+    static final String FEATURE = "aws-appconfig-data-config-source";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void awsAppConfigDataConfigFactory(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(AppConfigDataConfigSourceBuilder.class.getName()));
+    }
+}

--- a/services/appconfigdata/runtime/pom.xml
+++ b/services/appconfigdata/runtime/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigConfig.java
+++ b/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigConfig.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.amazon.appconfigdata.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.appconfigdata.config")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface AppConfigDataConfigConfig {
+    /**
+     * Whether to enable the AWS AppConfig Data ConfigSource ({@code quarkus.appconfigdata.config}).
+     * <p>
+     * When disabled, no configuration values are loaded from AppConfig Data.
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * AppConfig application ID or name for
+     * {@link software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest}.
+     */
+    Optional<String> application();
+
+    /**
+     * AppConfig environment ID or name for
+     * {@link software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest}.
+     */
+    Optional<String> environment();
+
+    /**
+     * AppConfig configuration profile ID or name for
+     * {@link software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest}.
+     */
+    Optional<String> configurationProfile();
+
+    /**
+     * Optional minimum interval between {@code GetLatestConfiguration} calls for the session.
+     */
+    Optional<Integer> requiredMinimumPollIntervalInSeconds();
+
+    /**
+     * Interval in minutes between polling for configuration updates after the initial fetch.
+     * <p>
+     * Set to {@code 0} to disable periodic polling (only the initial load runs).
+     */
+    @WithDefault("5")
+    int updateIntervalMinutes();
+
+}

--- a/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSource.java
+++ b/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSource.java
@@ -1,0 +1,276 @@
+package io.quarkiverse.amazon.appconfigdata.runtime;
+
+import static software.amazon.awssdk.utils.StringUtils.isBlank;
+
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import org.jboss.logging.Logger;
+
+import io.smallrye.config.common.AbstractConfigSource;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest;
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse;
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest;
+
+/**
+ * MicroProfile {@link org.eclipse.microprofile.config.spi.ConfigSource} backed by the AWS AppConfig Data API
+ * ({@code StartConfigurationSession} / {@code GetLatestConfiguration}).
+ * <p>
+ * <strong>Lifecycle</strong>
+ * <ul>
+ * <li>Opens a configuration session for the given application, environment, and configuration profile.</li>
+ * <li>Loads the hosted configuration document once during construction, then optionally on a fixed schedule.</li>
+ * <li>Owns the supplied {@link AppConfigDataClient}; callers must {@link #close()} it when the source is discarded.</li>
+ * </ul>
+ * <p>
+ * <strong>Parsing</strong> — The document body is interpreted as either JSON (objects and arrays are flattened to
+ * dotted keys and {@code [index]} segments) or Java {@link Properties} format. All values are exposed as strings.
+ * <p>
+ * <strong>Concurrency</strong> — The latest snapshot is published via {@link AtomicReference}; the poll token is
+ * {@code volatile}. {@link #getValue(String)} and {@link #getPropertyNames()} read the current snapshot without
+ * blocking the polling thread.
+ */
+public class AppConfigDataConfigSource extends AbstractConfigSource implements AutoCloseable {
+
+    private static final Logger LOG = Logger.getLogger(AppConfigDataConfigSource.class);
+    private static final String CONFIG_SOURCE_NAME = "quarkus.appconfigdata.config";
+
+    /** Background thread name for scheduled {@link #fetchConfig()} runs. */
+    private static final String POLL_THREAD_NAME = "quarkus-amazon-appconfigdata-config-poll";
+
+    /** Current flattened configuration; replaced atomically after each successful parse. */
+    private final AtomicReference<Map<String, String>> entriesRef = new AtomicReference<>(Map.of());
+
+    /** AWS client */
+    private final AppConfigDataClient client;
+
+    /**
+     * Session token for {@link GetLatestConfigurationRequest#configurationToken()}; updated from each response's
+     * {@link GetLatestConfigurationResponse#nextPollConfigurationToken()} (including when the payload is unchanged).
+     */
+    private volatile String token;
+
+    /** Non-null only when {@code updateIntervalMinutes &gt; 0} in the constructor. */
+    private ScheduledExecutorService executorService;
+
+    /**
+     * @param client client used for the session and polls; closed by {@link #close()}
+     * @param applicationIdentifier AppConfig application id or name
+     * @param environmentIdentifier AppConfig environment id or name
+     * @param configurationProfileIdentifier AppConfig configuration profile id or name
+     * @param requiredMinimumPollIntervalInSeconds optional minimum poll interval for the session (AWS)
+     * @param updateIntervalMinutes minutes between polls after the initial load; {@code 0} disables polling
+     * @param ordinal MicroProfile config source ordinal (precedence)
+     */
+    public AppConfigDataConfigSource(AppConfigDataClient client, String applicationIdentifier,
+            String environmentIdentifier, String configurationProfileIdentifier, Integer requiredMinimumPollIntervalInSeconds,
+            int updateIntervalMinutes, int ordinal) {
+        super(CONFIG_SOURCE_NAME, ordinal);
+        this.client = client;
+
+        if (isBlank(applicationIdentifier) || isBlank(environmentIdentifier) || isBlank(configurationProfileIdentifier)) {
+            LOG.error(
+                    "AppConfig Data ConfigSource requires applicationIdentifier, environmentIdentifier, and configurationProfileIdentifier.");
+            return;
+        }
+
+        token = startConfigurationSession(applicationIdentifier, environmentIdentifier, configurationProfileIdentifier,
+                requiredMinimumPollIntervalInSeconds);
+        fetchConfig();
+
+        if (updateIntervalMinutes > 0) {
+            LOG.debugf("Config update frequency set for %d minutes", updateIntervalMinutes);
+            ThreadFactory threadFactory = runnable -> new Thread(runnable, POLL_THREAD_NAME);
+            executorService = new ScheduledThreadPoolExecutor(1, threadFactory);
+            executorService.scheduleAtFixedRate(this::fetchConfig, updateIntervalMinutes, updateIntervalMinutes,
+                    TimeUnit.MINUTES);
+        }
+    }
+
+    /** Starts the AppConfig Data session and returns the initial poll token, or {@code null} on failure. */
+    private String startConfigurationSession(String applicationIdentifier, String environmentIdentifier,
+            String configurationProfileIdentifier, Integer requiredMinimumPollIntervalInSeconds) {
+        try {
+            LOG.infof("Starting configuration session for: [%s, %s, %s]", applicationIdentifier, environmentIdentifier,
+                    configurationProfileIdentifier);
+
+            var sessionBuilder = StartConfigurationSessionRequest.builder()
+                    .applicationIdentifier(applicationIdentifier.trim())
+                    .environmentIdentifier(environmentIdentifier.trim())
+                    .configurationProfileIdentifier(configurationProfileIdentifier.trim());
+            if (requiredMinimumPollIntervalInSeconds != null) {
+                sessionBuilder.requiredMinimumPollIntervalInSeconds(requiredMinimumPollIntervalInSeconds);
+            }
+
+            var session = client.startConfigurationSession(sessionBuilder.build());
+            String initialToken = session.initialConfigurationToken();
+            LOG.debugf("Got configuration token: %s", initialToken);
+            return initialToken;
+        } catch (Exception ex) {
+            LOG.errorf(ex, "Unable to start configuration session");
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the latest configuration using the current {@link #token}, advances the token from the response, and
+     * replaces {@link #entriesRef} when new non-empty content is present.
+     */
+    private void fetchConfig() {
+        if (token == null) {
+            LOG.warn("Config session token is null - skipping");
+            return;
+        }
+
+        LOG.debugf("Fetching configuration for token: %s", token);
+
+        GetLatestConfigurationResponse res = client.getLatestConfiguration(
+                GetLatestConfigurationRequest.builder().configurationToken(token).build());
+
+        // Always advance the poll token when AWS returns one, even if configuration is null (unchanged document).
+        String nextPoll = res.nextPollConfigurationToken();
+        if (nextPoll != null) {
+            token = nextPoll;
+        }
+
+        SdkBytes configuration = res.configuration();
+        if (configuration == null) {
+            LOG.debug("AppConfig Data returned no configuration payload (unchanged).");
+            return;
+        }
+
+        String configString = configuration.asUtf8String();
+        if (configString.isEmpty()) {
+            LOG.debug("No changes on the configuration received");
+            return;
+        }
+
+        try {
+            Map<String, String> parsed = parseConfiguration(configString);
+            entriesRef.set(Collections.unmodifiableMap(new LinkedHashMap<>(parsed)));
+            LOG.debugf("ConfigSource now exposes %d entries from AWS AppConfig Data.", parsed.size());
+        } catch (Exception ex) {
+            LOG.errorf(ex, "Unexpected failure reading the configuration");
+        }
+    }
+
+    /**
+     * Parses the hosted configuration body into a flat {@code Map}. If the trimmed content looks like JSON (starts
+     * with an object or array), it is parsed as JSON; otherwise as Java {@link Properties}.
+     */
+    static Map<String, String> parseConfiguration(String content) {
+        String trimmed = content.trim();
+        if (trimmed.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+            try (JsonReader reader = Json.createReader(new StringReader(trimmed))) {
+                JsonValue root = reader.readValue();
+                Map<String, String> flat = new LinkedHashMap<>();
+                flattenJson("", root, flat);
+                return flat;
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to parse configuration as JSON; treating as empty.");
+                return Collections.emptyMap();
+            }
+        }
+        // Use original content so properties files with leading comments or line continuations behave as expected.
+        Properties p = new Properties();
+        try {
+            p.load(new StringReader(content));
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to parse configuration as Java properties; treating as empty.");
+            return Collections.emptyMap();
+        }
+        Map<String, String> map = new LinkedHashMap<>();
+        for (String name : p.stringPropertyNames()) {
+            map.put(name, p.getProperty(name));
+        }
+        return map;
+    }
+
+    /**
+     * Flattens JSON into string keys: object keys are joined with {@code '.'}; array indices use {@code [n]}.
+     * {@code NULL} values are omitted. Scalar values are stored as strings.
+     */
+    private static void flattenJson(String prefix, JsonValue value, Map<String, String> out) {
+        switch (value.getValueType()) {
+            case OBJECT:
+                JsonObject obj = value.asJsonObject();
+                for (String key : obj.keySet()) {
+                    String p = prefix.isEmpty() ? key : prefix + "." + key;
+                    flattenJson(p, obj.get(key), out);
+                }
+                break;
+            case ARRAY:
+                JsonArray arr = value.asJsonArray();
+                for (int i = 0; i < arr.size(); i++) {
+                    flattenJson(prefix + "[" + i + "]", arr.get(i), out);
+                }
+                break;
+            case STRING:
+                out.put(prefix, ((JsonString) value).getString());
+                break;
+            case NUMBER:
+                out.put(prefix, value.toString());
+                break;
+            case TRUE:
+                out.put(prefix, "true");
+                break;
+            case FALSE:
+                out.put(prefix, "false");
+                break;
+            case NULL:
+            default:
+                break;
+        }
+    }
+
+    private Map<String, String> rawEntries() {
+        return entriesRef.get();
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return rawEntries().keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return rawEntries().get(propertyName);
+    }
+
+    @Override
+    public void close() {
+        if (executorService != null) {
+            executorService.shutdown();
+            try {
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+        client.close();
+    }
+}

--- a/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSourceBuilder.java
+++ b/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSourceBuilder.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.amazon.appconfigdata.runtime;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class AppConfigDataConfigSourceBuilder implements ConfigBuilder {
+
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withSources(new AppConfigDataConfigSourceFactory());
+    }
+}

--- a/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSourceFactory.java
+++ b/services/appconfigdata/runtime/src/main/java/io/quarkiverse/amazon/appconfigdata/runtime/AppConfigDataConfigSourceFactory.java
@@ -1,0 +1,84 @@
+package io.quarkiverse.amazon.appconfigdata.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalInt;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.quarkiverse.amazon.common.runtime.AmazonClientCommonRecorder;
+import io.quarkiverse.amazon.common.runtime.AmazonClientConfig;
+import io.quarkiverse.amazon.common.runtime.ClientUtil;
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClientBuilder;
+
+public class AppConfigDataConfigSourceFactory implements
+        ConfigSourceFactory.ConfigurableConfigSourceFactory<AppConfigDataConfigConfig> {
+
+    /**
+     * The ordinal is set to < 100 (which is the default) so that this config source is retrieved from last.
+     */
+    private static final int ORDINAL = 50;
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(
+            final ConfigSourceContext configSourceContext,
+            final AppConfigDataConfigConfig appConfigDataConfig) {
+
+        if (!appConfigDataConfig.enabled()) {
+            return Collections.emptyList();
+        }
+
+        var clientConfig = getClientConfig(configSourceContext);
+
+        AppConfigDataClient client = build(clientConfig);
+        return Collections.singletonList(new AppConfigDataConfigSource(client,
+                appConfigDataConfig.application().orElse(null),
+                appConfigDataConfig.environment().orElse(null),
+                appConfigDataConfig.configurationProfile().orElse(null),
+                appConfigDataConfig.requiredMinimumPollIntervalInSeconds().orElse(null),
+                appConfigDataConfig.updateIntervalMinutes(),
+                ORDINAL));
+    }
+
+    AppConfigDataClient build(AppConfigDataConfig config) throws RuntimeException {
+        final AppConfigDataClientBuilder builder = AppConfigDataClient.builder()
+                .httpClientBuilder(UrlConnectionHttpClient.builder());
+
+        AmazonClientConfig defaultConfig = config.clients().get(ClientUtil.DEFAULT_CLIENT_NAME);
+
+        AmazonClientCommonRecorder.initAwsClient(builder, "appconfigdata", "appconfigdata", defaultConfig.aws(),
+                defaultConfig.aws());
+        AmazonClientCommonRecorder.initSdkClientEndpoint(builder, "appconfigdata", "appconfigdata", defaultConfig.sdk(),
+                defaultConfig.sdk());
+
+        return builder.build();
+    }
+
+    AppConfigDataConfig getClientConfig(ConfigSourceContext context) {
+
+        List<String> profiles = new ArrayList<>(context.getProfiles());
+        Collections.reverse(profiles);
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withProfiles(profiles)
+                .withSources(new ConfigSourceContext.ConfigSourceContextConfigSource(context))
+                .withSources(context.getConfigSources())
+                .withMapping(AppConfigDataConfig.class)
+                .withValidateUnknown(false)
+                .build();
+
+        return config.getConfigMapping(AppConfigDataConfig.class);
+    }
+
+    @Override
+    public OptionalInt getPriority() {
+        return OptionalInt.of(ORDINAL);
+    }
+}

--- a/services/ssm/deployment/src/main/java/io/quarkiverse/amazon/ssm/deployment/SsmConfigSourceProcessor.java
+++ b/services/ssm/deployment/src/main/java/io/quarkiverse/amazon/ssm/deployment/SsmConfigSourceProcessor.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.amazon.ssm.deployment;
+
+import io.quarkiverse.amazon.ssm.runtime.SsmConfigSourceBuilder;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
+
+public class SsmConfigSourceProcessor {
+
+    static final String FEATURE = "aws-ssm-parameter-store-config-source";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void ssmConfigSourceFactory(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(SsmConfigSourceBuilder.class.getName()));
+    }
+}

--- a/services/ssm/runtime/pom.xml
+++ b/services/ssm/runtime/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigConfig.java
+++ b/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigConfig.java
@@ -1,0 +1,55 @@
+package io.quarkiverse.amazon.ssm.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Runtime configuration for the Parameter Store {@link SsmConfigSource}.
+ */
+@ConfigMapping(prefix = "quarkus.ssm.config")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface SsmConfigConfig {
+
+    /**
+     * Whether to enable the AWS Systems Manager Parameter Store ConfigSource ({@code quarkus.ssm.config}).
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Parameter Store path passed to {@link software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest}.
+     * When set, all parameters under this path are loaded (subject to {@link #recursive()}).
+     */
+    Optional<String> path();
+
+    /**
+     * Individual parameter names (full paths, for example {@code /myapp/prod/db/url}) passed to
+     * {@link software.amazon.awssdk.services.ssm.model.GetParametersRequest}. Batched in groups of ten per AWS limit.
+     * <p>
+     * You can combine this with {@link #path()}; the merged result is exposed as configuration keys.
+     */
+    Optional<List<String>> names();
+
+    /**
+     * When using {@link #path()}, whether to load parameters in sub-paths recursively.
+     */
+    @WithDefault("true")
+    boolean recursive();
+
+    /**
+     * Whether to decrypt {@code SecureString} parameters when fetching values.
+     */
+    @WithDefault("true")
+    boolean withDecryption();
+
+    /**
+     * Interval in minutes between reloads after the initial fetch. Set to {@code 0} to fetch only once at startup.
+     */
+    @WithDefault("5")
+    int updateIntervalMinutes();
+}

--- a/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSource.java
+++ b/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSource.java
@@ -1,0 +1,284 @@
+package io.quarkiverse.amazon.ssm.runtime;
+
+import static software.amazon.awssdk.utils.StringUtils.isBlank;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import org.jboss.logging.Logger;
+
+import io.smallrye.config.common.AbstractConfigSource;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.GetParametersRequest;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+
+/**
+ * MicroProfile {@link org.eclipse.microprofile.config.spi.ConfigSource} backed by AWS Systems Manager Parameter Store.
+ * <p>
+ * Loads parameters by path ({@code GetParametersByPath}) and/or explicit names ({@code GetParameters}), maps each
+ * parameter value into one or more configuration keys, then optionally reloads on a fixed interval.
+ * <p>
+ * Parameter names are normalized into MicroProfile-friendly keys by stripping a leading {@code '/'} and replacing
+ * remaining slashes with {@code '.'} (for example {@code /myapp/prod/url} becomes {@code myapp.prod.url}).
+ * <p>
+ * A parameter value that is JSON (object or array) is flattened like the AppConfig Data config source; inner keys are
+ * prefixed with the normalized parameter name. Other values are exposed as a single key (the normalized name) unless
+ * the value looks like Java properties text (contains an equals sign), in which case each entry is prefixed.
+ * <p>
+ * The supplied {@link SsmClient} is owned by this source and closed in {@link #close()}.
+ */
+public class SsmConfigSource extends AbstractConfigSource implements AutoCloseable {
+
+    private static final Logger LOG = Logger.getLogger(SsmConfigSource.class);
+    private static final String CONFIG_SOURCE_NAME = "quarkus.ssm.config";
+
+    private static final String POLL_THREAD_NAME = "quarkus-amazon-ssm-config-poll";
+
+    /** AWS allows at most ten names per {@link GetParametersRequest}. */
+    private static final int GET_PARAMETERS_BATCH_SIZE = 10;
+
+    private final AtomicReference<Map<String, String>> entriesRef = new AtomicReference<>(Map.of());
+    private final SsmClient client;
+    private final String path;
+    private final List<String> names;
+    private final boolean recursive;
+    private final boolean withDecryption;
+
+    private ScheduledExecutorService executorService;
+
+    public SsmConfigSource(SsmClient client, String path, List<String> names, boolean recursive, boolean withDecryption,
+            int updateIntervalMinutes, int ordinal) {
+        super(CONFIG_SOURCE_NAME, ordinal);
+        this.client = client;
+        this.path = path;
+        this.names = names != null ? List.copyOf(names) : List.of();
+        this.recursive = recursive;
+        this.withDecryption = withDecryption;
+
+        reload();
+
+        if (updateIntervalMinutes > 0) {
+            LOG.debugf("SSM ConfigSource update interval set to %d minutes", updateIntervalMinutes);
+            ThreadFactory threadFactory = runnable -> new Thread(runnable, POLL_THREAD_NAME);
+            executorService = new ScheduledThreadPoolExecutor(1, threadFactory);
+            executorService.scheduleAtFixedRate(this::reload, updateIntervalMinutes, updateIntervalMinutes,
+                    TimeUnit.MINUTES);
+        }
+    }
+
+    private void reload() {
+        try {
+            Map<String, String> merged = new LinkedHashMap<>();
+            if (!isBlank(path)) {
+                mergeParametersByPath(merged, path.trim());
+            }
+            for (List<String> batch : partition(names, GET_PARAMETERS_BATCH_SIZE)) {
+                mergeParametersByName(merged, batch);
+            }
+            entriesRef.set(Collections.unmodifiableMap(merged));
+            LOG.debugf("SSM ConfigSource now exposes %d configuration entries.", merged.size());
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to reload configuration from AWS Systems Manager Parameter Store.");
+        }
+    }
+
+    private void mergeParametersByPath(Map<String, String> target, String pathValue) {
+        String nextToken = null;
+        do {
+            var reqBuilder = GetParametersByPathRequest.builder()
+                    .path(normalizePath(pathValue))
+                    .recursive(recursive)
+                    .withDecryption(withDecryption);
+            if (nextToken != null) {
+                reqBuilder.nextToken(nextToken);
+            }
+            var response = client.getParametersByPath(reqBuilder.build());
+            nextToken = response.nextToken();
+            for (Parameter p : response.parameters()) {
+                mergeParameter(target, p.name(), p.value());
+            }
+        } while (nextToken != null && !nextToken.isEmpty());
+    }
+
+    private void mergeParametersByName(Map<String, String> target, List<String> batch) {
+        if (batch.isEmpty()) {
+            return;
+        }
+        var response = client.getParameters(GetParametersRequest.builder()
+                .names(batch)
+                .withDecryption(withDecryption)
+                .build());
+        for (Parameter p : response.parameters()) {
+            mergeParameter(target, p.name(), p.value());
+        }
+        if (!response.invalidParameters().isEmpty()) {
+            LOG.warnf("SSM GetParameters reported invalid parameter names: %s", response.invalidParameters());
+        }
+    }
+
+    private static void mergeParameter(Map<String, String> target, String awsName, String value) {
+        target.putAll(expandParameterValue(awsName, value));
+    }
+
+    /**
+     * Turns a Parameter Store name into a configuration key prefix (no leading slash, {@code '/'} to {@code '.'}).
+     */
+    static String normalizeParameterName(String name) {
+        if (name == null) {
+            return "";
+        }
+        String n = name.trim();
+        if (n.startsWith("/")) {
+            n = n.substring(1);
+        }
+        return n.replace('/', '.');
+    }
+
+    static String normalizePath(String pathValue) {
+        if (pathValue == null || pathValue.isEmpty()) {
+            return "/";
+        }
+        return pathValue.startsWith("/") ? pathValue : "/" + pathValue;
+    }
+
+    /**
+     * Maps one parameter's value to zero or more configuration keys under {@link #normalizeParameterName(String)}.
+     */
+    static Map<String, String> expandParameterValue(String awsName, String value) {
+        String prefix = normalizeParameterName(awsName);
+        if (prefix.isEmpty()) {
+            return Map.of();
+        }
+        if (value == null) {
+            return Map.of();
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return Map.of();
+        }
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+            try (JsonReader reader = Json.createReader(new StringReader(trimmed))) {
+                Map<String, String> flat = new LinkedHashMap<>();
+                flattenJson("", reader.readValue(), flat);
+                if (flat.isEmpty()) {
+                    return Map.of(prefix, value);
+                }
+                Map<String, String> out = new LinkedHashMap<>();
+                for (Map.Entry<String, String> e : flat.entrySet()) {
+                    String k = e.getKey().isEmpty() ? prefix : prefix + "." + e.getKey();
+                    out.put(k, e.getValue());
+                }
+                return out;
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to parse JSON for SSM parameter '%s'; exposing raw string.", awsName);
+                return Map.of(prefix, value);
+            }
+        }
+        if (trimmed.contains("=")) {
+            Properties p = new Properties();
+            try {
+                p.load(new StringReader(value));
+            } catch (Exception e) {
+                return Map.of(prefix, value);
+            }
+            if (!p.stringPropertyNames().isEmpty()) {
+                Map<String, String> out = new LinkedHashMap<>();
+                for (String n : p.stringPropertyNames()) {
+                    out.put(prefix + "." + n, p.getProperty(n));
+                }
+                return out;
+            }
+        }
+        return Map.of(prefix, value);
+    }
+
+    private static void flattenJson(String keyPrefix, JsonValue value, Map<String, String> out) {
+        switch (value.getValueType()) {
+            case OBJECT:
+                JsonObject obj = value.asJsonObject();
+                for (String key : obj.keySet()) {
+                    String p = keyPrefix.isEmpty() ? key : keyPrefix + "." + key;
+                    flattenJson(p, obj.get(key), out);
+                }
+                break;
+            case ARRAY:
+                JsonArray arr = value.asJsonArray();
+                for (int i = 0; i < arr.size(); i++) {
+                    flattenJson(keyPrefix + "[" + i + "]", arr.get(i), out);
+                }
+                break;
+            case STRING:
+                out.put(keyPrefix, ((JsonString) value).getString());
+                break;
+            case NUMBER:
+                out.put(keyPrefix, value.toString());
+                break;
+            case TRUE:
+                out.put(keyPrefix, "true");
+                break;
+            case FALSE:
+                out.put(keyPrefix, "false");
+                break;
+            case NULL:
+            default:
+                break;
+        }
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> parts = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            parts.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return parts;
+    }
+
+    private Map<String, String> rawEntries() {
+        return entriesRef.get();
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return rawEntries().keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return rawEntries().get(propertyName);
+    }
+
+    @Override
+    public void close() {
+        if (executorService != null) {
+            executorService.shutdown();
+            try {
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+        client.close();
+    }
+}

--- a/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSourceBuilder.java
+++ b/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSourceBuilder.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.amazon.ssm.runtime;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class SsmConfigSourceBuilder implements ConfigBuilder {
+
+    @Override
+    public SmallRyeConfigBuilder configBuilder(SmallRyeConfigBuilder builder) {
+        return builder.withSources(new SsmConfigSourceFactory());
+    }
+}

--- a/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSourceFactory.java
+++ b/services/ssm/runtime/src/main/java/io/quarkiverse/amazon/ssm/runtime/SsmConfigSourceFactory.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.amazon.ssm.runtime;
+
+import static software.amazon.awssdk.utils.StringUtils.isBlank;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.amazon.common.runtime.AmazonClientCommonRecorder;
+import io.quarkiverse.amazon.common.runtime.AmazonClientConfig;
+import io.quarkiverse.amazon.common.runtime.ClientUtil;
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+
+public class SsmConfigSourceFactory implements ConfigSourceFactory.ConfigurableConfigSourceFactory<SsmConfigConfig> {
+
+    private static final Logger LOG = Logger.getLogger(SsmConfigSourceFactory.class);
+
+    private static final int ORDINAL = 50;
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ConfigSourceContext configSourceContext, SsmConfigConfig ssmConfig) {
+
+        if (!ssmConfig.enabled()) {
+            return Collections.emptyList();
+        }
+
+        Optional<String> pathOpt = ssmConfig.path().filter(p -> !isBlank(p));
+        List<String> names = sanitizeNames(ssmConfig.names().orElse(List.of()));
+
+        if (pathOpt.isEmpty() && names.isEmpty()) {
+            LOG.error(
+                    "SSM ConfigSource is enabled but neither quarkus.ssm.config.path nor quarkus.ssm.config.names is set.");
+            return Collections.emptyList();
+        }
+
+        SsmConfig clientConfig = getClientConfig(configSourceContext);
+        SsmClient client = build(clientConfig);
+        return Collections.singletonList(new SsmConfigSource(client, pathOpt.orElse(null), names, ssmConfig.recursive(),
+                ssmConfig.withDecryption(), ssmConfig.updateIntervalMinutes(), ORDINAL));
+    }
+
+    private static List<String> sanitizeNames(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>();
+        for (String n : names) {
+            if (n != null && !isBlank(n)) {
+                out.add(n.trim());
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    SsmClient build(SsmConfig config) {
+        SsmClientBuilder builder = SsmClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder());
+        AmazonClientConfig defaultConfig = config.clients().get(ClientUtil.DEFAULT_CLIENT_NAME);
+        AmazonClientCommonRecorder.initAwsClient(builder, "ssm", "ssm", defaultConfig.aws(), defaultConfig.aws());
+        AmazonClientCommonRecorder.initSdkClientEndpoint(builder, "ssm", "ssm", defaultConfig.sdk(), defaultConfig.sdk());
+        return builder.build();
+    }
+
+    SsmConfig getClientConfig(ConfigSourceContext context) {
+        List<String> profiles = new ArrayList<>(context.getProfiles());
+        Collections.reverse(profiles);
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withProfiles(profiles)
+                .withSources(new ConfigSourceContext.ConfigSourceContextConfigSource(context))
+                .withSources(context.getConfigSources())
+                .withMapping(SsmConfig.class)
+                .withValidateUnknown(false)
+                .build();
+        return config.getConfigMapping(SsmConfig.class);
+    }
+
+    @Override
+    public OptionalInt getPriority() {
+        return OptionalInt.of(ORDINAL);
+    }
+}

--- a/services/ssm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/services/ssm/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,7 @@ metadata:
     - "amazon"
   categories:
     - "data"
+    - "configuration"
   guide: https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-ssm.html
   status: "stable"
   config:


### PR DESCRIPTION
This takes the code we created for SecretsManager ConfigSource and applies it to AppConfigData but uses @brucej72gg example code to optionally poll for changes and update the configuration

Fix #1859: AppConfigData as a ConfigSource
FIx #1889

