### PR TITLE
feat: update to opentelemetry-aws-sdk-2.2 2.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Quarkus Amazon Services provides multiple version streams. One stream is compati
 | 3.27.x (LTS) | 3.9.x (bug fixes only)  | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/3.9.x/index.html)    |
 | [3.29, 3.33) | [3.12.0, 3.15)          | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/3.13.x/index.html)   |
 | 3.33.x (LTS) | 3.15.x (bug fixes only) | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/3.15.x/index.html)   |
-| [3.34, )     | [3.16, )                | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/dev/index.html)      |
+| [3.34]       | [3.16]                  | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/3.16.x/index.html)   |
+| [3.35, )     | [3.17, )                | [Documentation](https://docs.quarkiverse.io/quarkus-amazon-services/dev/index.html)      |
 
 Use the latest version of the corresponding stream, [the list of versions is available on Maven Central](https://search.maven.org/artifact/io.quarkiverse.amazonservices/quarkus-amazon-services-bom).
 

--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientOpenTelemetryRecorder.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientOpenTelemetryRecorder.java
@@ -20,7 +20,7 @@ public class AmazonClientOpenTelemetryRecorder {
 
                 builder.overrideConfiguration(
                         builder.overrideConfiguration().toBuilder()
-                                .addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor())
+                                .addExecutionInterceptor(awsSdkTelemetry.createExecutionInterceptor())
                                 .build());
 
                 return builder;

--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AwsSdkTelemetryConfig.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AwsSdkTelemetryConfig.java
@@ -24,6 +24,11 @@ public interface AwsSdkTelemetryConfig {
      */
     AwsSdkConfig awsSdk();
 
+    /**
+     * Gen AI configuration
+     */
+    GenAIConfig genai();
+
     @ConfigGroup
     public interface AwsSdkConfig {
         /**
@@ -95,5 +100,18 @@ public interface AwsSdkTelemetryConfig {
             @WithDefault("false")
             Optional<Boolean> receiveTelemetryEnabled();
         }
+    }
+
+    @ConfigGroup
+    public interface GenAIConfig {
+        /**
+         * Set whether Generative AI events include full content of user and
+         * assistant messages.
+         *
+         * Note that full content can have data privacy and size concerns and care
+         * should be taken when enabling this.
+         */
+        @WithDefault("false")
+        Optional<Boolean> captureMessageContent();
     }
 }

--- a/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AwsSdkTelemetryProducer.java
+++ b/common/runtime/src/main/java/io/quarkiverse/amazon/common/runtime/AwsSdkTelemetryProducer.java
@@ -19,10 +19,11 @@ public class AwsSdkTelemetryProducer {
 
         config.messaging().experimental().captureHeaders().ifPresent(builder::setCapturedHeaders);
         config.messaging().experimental().receiveTelemetryEnabled()
-                .ifPresent(builder::setMessagingReceiveInstrumentationEnabled);
+                .ifPresent(builder::setMessagingReceiveTelemetryEnabled);
         config.awsSdk().experimentalUsePropagatorForMessaging().ifPresent(builder::setUseConfiguredPropagatorForMessaging);
         config.awsSdk().experimentalRecordIndividualHttpError().ifPresent(builder::setRecordIndividualHttpError);
         config.awsSdk().experimentalSpanAttributes().ifPresent(builder::setCaptureExperimentalSpanAttributes);
+        config.genai().captureMessageContent().ifPresent(builder::setGenaiCaptureMessageContent);
 
         return builder.build();
     }

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.34.1
+:quarkus-version: 3.35.0.CR1
 :quarkus-amazon-services-version: 3.16.0
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon.adoc
@@ -7,9 +7,9 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-capture-headers]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-capture-headers[`+++quarkus.otel.instrumentation.messaging.experimental.capture-headers+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-messaging-experimental-capture-headers]] [.property-path]##link:#quarkus-amazon_quarkus-messaging-experimental-capture-headers[`+++quarkus.messaging.experimental.capture-headers+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.messaging.experimental.capture-headers+++[]
+config_property_copy_button:+++quarkus.messaging.experimental.capture-headers+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -19,18 +19,18 @@ Configures the messaging headers that will be captured as span attributes.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++`
+Environment variable: `+++QUARKUS_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
 |
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-receive-telemetry-enabled]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-receive-telemetry-enabled[`+++quarkus.otel.instrumentation.messaging.experimental.receive-telemetry.enabled+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-messaging-experimental-receive-telemetry-enabled]] [.property-path]##link:#quarkus-amazon_quarkus-messaging-experimental-receive-telemetry-enabled[`+++quarkus.messaging.experimental.receive-telemetry.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.messaging.experimental.receive-telemetry.enabled+++[]
+config_property_copy_button:+++quarkus.messaging.experimental.receive-telemetry.enabled+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -40,18 +40,18 @@ Set whether to capture the consumer message receive telemetry in messaging instr
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++`
+Environment variable: `+++QUARKUS_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-span-attributes]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-span-attributes[`+++quarkus.otel.instrumentation.aws-sdk.experimental-span-attributes+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-span-attributes]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-span-attributes[`+++quarkus.aws-sdk.experimental-span-attributes+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-span-attributes+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-span-attributes+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -61,18 +61,18 @@ Sets whether experimental attributes should be set to spans. These attributes ma
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-use-propagator-for-messaging]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-use-propagator-for-messaging[`+++quarkus.otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-use-propagator-for-messaging]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-use-propagator-for-messaging[`+++quarkus.aws-sdk.experimental-use-propagator-for-messaging+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-use-propagator-for-messaging+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -82,18 +82,18 @@ Sets whether the io.opentelemetry.context.propagation.TextMapPropagator configur
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-record-individual-http-error]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-record-individual-http-error[`+++quarkus.otel.instrumentation.aws-sdk.experimental-record-individual-http-error+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-record-individual-http-error]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-record-individual-http-error[`+++quarkus.aws-sdk.experimental-record-individual-http-error+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-record-individual-http-error+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-record-individual-http-error+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -103,18 +103,18 @@ Sets whether errors returned by each individual HTTP request should be recorded 
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-genai-capture-message-content]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-genai-capture-message-content[`+++quarkus.otel.instrumentation.genai.capture-message-content+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-genai-capture-message-content]] [.property-path]##link:#quarkus-amazon_quarkus-genai-capture-message-content[`+++quarkus.genai.capture-message-content+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.genai.capture-message-content+++[]
+config_property_copy_button:+++quarkus.genai.capture-message-content+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -124,10 +124,10 @@ Set whether Generative AI events include full content of user and assistant mess
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GENAI_CAPTURE_MESSAGE_CONTENT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT+++`
+Environment variable: `+++QUARKUS_GENAI_CAPTURE_MESSAGE_CONTENT+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-amazon_quarkus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-amazon_quarkus.adoc
@@ -7,9 +7,9 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-capture-headers]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-capture-headers[`+++quarkus.otel.instrumentation.messaging.experimental.capture-headers+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-messaging-experimental-capture-headers]] [.property-path]##link:#quarkus-amazon_quarkus-messaging-experimental-capture-headers[`+++quarkus.messaging.experimental.capture-headers+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.messaging.experimental.capture-headers+++[]
+config_property_copy_button:+++quarkus.messaging.experimental.capture-headers+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -19,18 +19,18 @@ Configures the messaging headers that will be captured as span attributes.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++`
+Environment variable: `+++QUARKUS_MESSAGING_EXPERIMENTAL_CAPTURE_HEADERS+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
 |
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-receive-telemetry-enabled]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-messaging-experimental-receive-telemetry-enabled[`+++quarkus.otel.instrumentation.messaging.experimental.receive-telemetry.enabled+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-messaging-experimental-receive-telemetry-enabled]] [.property-path]##link:#quarkus-amazon_quarkus-messaging-experimental-receive-telemetry-enabled[`+++quarkus.messaging.experimental.receive-telemetry.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.messaging.experimental.receive-telemetry.enabled+++[]
+config_property_copy_button:+++quarkus.messaging.experimental.receive-telemetry.enabled+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -40,18 +40,18 @@ Set whether to capture the consumer message receive telemetry in messaging instr
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++`
+Environment variable: `+++QUARKUS_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-span-attributes]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-span-attributes[`+++quarkus.otel.instrumentation.aws-sdk.experimental-span-attributes+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-span-attributes]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-span-attributes[`+++quarkus.aws-sdk.experimental-span-attributes+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-span-attributes+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-span-attributes+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -61,18 +61,18 @@ Sets whether experimental attributes should be set to spans. These attributes ma
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-use-propagator-for-messaging]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-use-propagator-for-messaging[`+++quarkus.otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-use-propagator-for-messaging]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-use-propagator-for-messaging[`+++quarkus.aws-sdk.experimental-use-propagator-for-messaging+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-use-propagator-for-messaging+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -82,18 +82,18 @@ Sets whether the io.opentelemetry.context.propagation.TextMapPropagator configur
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-record-individual-http-error]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-aws-sdk-experimental-record-individual-http-error[`+++quarkus.otel.instrumentation.aws-sdk.experimental-record-individual-http-error+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-aws-sdk-experimental-record-individual-http-error]] [.property-path]##link:#quarkus-amazon_quarkus-aws-sdk-experimental-record-individual-http-error[`+++quarkus.aws-sdk.experimental-record-individual-http-error+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.aws-sdk.experimental-record-individual-http-error+++[]
+config_property_copy_button:+++quarkus.aws-sdk.experimental-record-individual-http-error+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -103,18 +103,18 @@ Sets whether errors returned by each individual HTTP request should be recorded 
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++`
+Environment variable: `+++QUARKUS_AWS_SDK_EXPERIMENTAL_RECORD_INDIVIDUAL_HTTP_ERROR+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
 
-a| [[quarkus-amazon_quarkus-otel-instrumentation-genai-capture-message-content]] [.property-path]##link:#quarkus-amazon_quarkus-otel-instrumentation-genai-capture-message-content[`+++quarkus.otel.instrumentation.genai.capture-message-content+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-amazon_quarkus-genai-capture-message-content]] [.property-path]##link:#quarkus-amazon_quarkus-genai-capture-message-content[`+++quarkus.genai.capture-message-content+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.otel.instrumentation.genai.capture-message-content+++[]
+config_property_copy_button:+++quarkus.genai.capture-message-content+++[]
 endif::add-copy-button-to-config-props[]
 
 
@@ -124,10 +124,10 @@ Set whether Generative AI events include full content of user and assistant mess
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GENAI_CAPTURE_MESSAGE_CONTENT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT+++`
+Environment variable: `+++QUARKUS_GENAI_CAPTURE_MESSAGE_CONTENT+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/opentelemetry.adoc
+++ b/docs/modules/ROOT/pages/opentelemetry.adoc
@@ -6,6 +6,8 @@ Adding the `quarkus-opentelemetry` extension will automatically inject an interc
 
 Quarkus Amazon Services supports the OpenTelemetry Autoconfiguration for Traces. The configurations match what you can see at OpenTelemetry SDK Autoconfigure with the `quarkus.*` prefix.
 
+NOTE: It is not necessary to wrap Sqs or Bedrock Runtime clients, the extensions does it for you when telemetry is enabled for those clients.
+
 If necessary, you can provide your own AwsSdkTelemetry instance used to instrument all clients.
 
 [source,java]

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -63,6 +63,7 @@ quarkus.sts.async-client.type=${async-client.type}
 
 quarkus.s3.telemetry.enabled=true
 quarkus.sqs.telemetry.enabled=true
+quarkus.bedrockruntime.telemetry.enabled=true
 
 quarkus.iam.custom.aws.credentials.type=static
 quarkus.iam.custom.aws.credentials.static-provider.access-key-id=112233445566

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- https://github.com/quarkusio/quarkus/releases -->
-    <quarkus.version>3.34.5</quarkus.version>
+    <quarkus.version>3.35.0.CR1</quarkus.version>
 
     <!-- https://github.com/aws/aws-sdk-java-v2/releases -->
     <awssdk.version>2.42.22</awssdk.version>

--- a/services/bedrockruntime/deployment/src/main/java/io/quarkiverse/amazon/bedrockruntime/deployment/BedrockRuntimeOtelProcessor.java
+++ b/services/bedrockruntime/deployment/src/main/java/io/quarkiverse/amazon/bedrockruntime/deployment/BedrockRuntimeOtelProcessor.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.amazon.bedrockruntime.deployment;
+
+import static io.quarkiverse.amazon.common.deployment.ClientDeploymentUtil.namedBuilder;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.jandex.ClassType;
+
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
+import io.quarkiverse.amazon.bedrockruntime.runtime.BedrockRuntimeOpenTelemetryRecorder;
+import io.quarkiverse.amazon.common.deployment.AmazonClientBuilderBuildItem;
+import io.quarkiverse.amazon.common.deployment.AmazonClientBuilderOverrideBuildItem;
+import io.quarkiverse.amazon.common.deployment.RequireAmazonTelemetryBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClientBuilder;
+
+public class BedrockRuntimeOtelProcessor {
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void wrapClientBuilders(List<AmazonClientBuilderBuildItem> clientBuilders,
+            List<RequireAmazonTelemetryBuildItem> amazonRequireTelemtryClients,
+            BedrockRuntimeOpenTelemetryRecorder otelRecorder,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            BuildProducer<AmazonClientBuilderOverrideBuildItem> overrides) {
+
+        boolean addOpenTelemetry = amazonRequireTelemtryClients
+                .stream()
+                .anyMatch(c -> "bedrockruntime".equals(c.getConfigName()));
+
+        if (!addOpenTelemetry) {
+            return;
+        }
+
+        for (AmazonClientBuilderBuildItem clientBuilder : clientBuilders) {
+            if (clientBuilder.getBuilderClass().equals(BedrockRuntimeAsyncClientBuilder.class)) {
+
+                syntheticBeans.produce(namedBuilder(SyntheticBeanBuildItem.configure(clientBuilder.getBuilderClass()),
+                        clientBuilder.getClientName())
+                        .unremovable()
+                        .defaultBean()
+                        .setRuntimeInit()
+                        .scope(ApplicationScoped.class)
+                        .createWith(otelRecorder.configureAsync(clientBuilder.getClientBuilder()))
+                        .addInjectionPoint(ClassType.create(AwsSdkTelemetry.class)).done());
+                overrides.produce(new AmazonClientBuilderOverrideBuildItem(
+                        clientBuilder.getBuilderClass(),
+                        clientBuilder.getClientName()));
+            }
+        }
+    }
+}

--- a/services/bedrockruntime/runtime/pom.xml
+++ b/services/bedrockruntime/runtime/pom.xml
@@ -74,6 +74,11 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/bedrockruntime/runtime/src/main/java/io/quarkiverse/amazon/bedrockruntime/runtime/BedrockRuntimeOpenTelemetryRecorder.java
+++ b/services/bedrockruntime/runtime/src/main/java/io/quarkiverse/amazon/bedrockruntime/runtime/BedrockRuntimeOpenTelemetryRecorder.java
@@ -1,0 +1,110 @@
+package io.quarkiverse.amazon.bedrockruntime.runtime;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.client.config.ClientAsyncConfiguration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClientBuilder;
+
+@Recorder
+public class BedrockRuntimeOpenTelemetryRecorder {
+
+    private final class TelemetryEnabledBedrockRuntimeAsyncClientBuilder
+            implements BedrockRuntimeAsyncClientBuilder {
+
+        private BedrockRuntimeAsyncClientBuilder baseBuilder;
+        private AwsSdkTelemetry awsSdkTelemetry;
+
+        public TelemetryEnabledBedrockRuntimeAsyncClientBuilder(BedrockRuntimeAsyncClientBuilder baseBuilder,
+                AwsSdkTelemetry awsSdkTelemetry) {
+            this.baseBuilder = baseBuilder;
+            this.awsSdkTelemetry = awsSdkTelemetry;
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder asyncConfiguration(ClientAsyncConfiguration clientAsyncConfiguration) {
+            return baseBuilder.asyncConfiguration(clientAsyncConfiguration);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder httpClient(SdkAsyncHttpClient httpClient) {
+            return baseBuilder.httpClient(httpClient);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder httpClientBuilder(
+                software.amazon.awssdk.http.async.SdkAsyncHttpClient.Builder httpClientBuilder) {
+            return baseBuilder.httpClientBuilder(httpClientBuilder);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder region(Region region) {
+            return baseBuilder.region(region);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder dualstackEnabled(Boolean dualstackEndpointEnabled) {
+            return baseBuilder.dualstackEnabled(dualstackEndpointEnabled);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder fipsEnabled(Boolean fipsEndpointEnabled) {
+            return baseBuilder.fipsEnabled(fipsEndpointEnabled);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder overrideConfiguration(ClientOverrideConfiguration overrideConfiguration) {
+            return baseBuilder.overrideConfiguration(overrideConfiguration);
+        }
+
+        @Override
+        public ClientOverrideConfiguration overrideConfiguration() {
+            return baseBuilder.overrideConfiguration();
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClientBuilder endpointOverride(URI endpointOverride) {
+            return baseBuilder.endpointOverride(endpointOverride);
+        }
+
+        @Override
+        public BedrockRuntimeAsyncClient build() {
+            return awsSdkTelemetry.wrapBedrockRuntimeClient(baseBuilder.build());
+        }
+    }
+
+    public Function<SyntheticCreationalContext<AwsClientBuilder>, AwsClientBuilder> configureAsync(
+            RuntimeValue<AwsClientBuilder> clientBuilder) {
+        return new Function<SyntheticCreationalContext<AwsClientBuilder>, AwsClientBuilder>() {
+            @Override
+            public AwsClientBuilder apply(SyntheticCreationalContext<AwsClientBuilder> context) {
+                AwsClientBuilder builder = clientBuilder.getValue();
+                AwsSdkTelemetry awsSdkTelemetry = context.getInjectedReference(AwsSdkTelemetry.class);
+
+                builder.overrideConfiguration(
+                        builder.overrideConfiguration().toBuilder()
+                                .addExecutionInterceptor(awsSdkTelemetry.createExecutionInterceptor())
+                                .build());
+
+                return wrapAsyncClientBuilder(builder, awsSdkTelemetry);
+            }
+        };
+    }
+
+    protected AwsClientBuilder wrapAsyncClientBuilder(AwsClientBuilder clientBuilder,
+            AwsSdkTelemetry awsSdkTelemetry) {
+
+        return (AwsClientBuilder) new TelemetryEnabledBedrockRuntimeAsyncClientBuilder(
+                (BedrockRuntimeAsyncClientBuilder) clientBuilder,
+                awsSdkTelemetry);
+    }
+}

--- a/sqs/runtime/src/main/java/io/quarkiverse/amazon/sqs/runtime/SqsOpenTelemetryRecorder.java
+++ b/sqs/runtime/src/main/java/io/quarkiverse/amazon/sqs/runtime/SqsOpenTelemetryRecorder.java
@@ -163,7 +163,7 @@ public class SqsOpenTelemetryRecorder {
 
                 builder.overrideConfiguration(
                         builder.overrideConfiguration().toBuilder()
-                                .addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor())
+                                .addExecutionInterceptor(awsSdkTelemetry.createExecutionInterceptor())
                                 .build());
 
                 return wrapSyncClientBuilder(builder, awsSdkTelemetry);
@@ -181,7 +181,7 @@ public class SqsOpenTelemetryRecorder {
 
                 builder.overrideConfiguration(
                         builder.overrideConfiguration().toBuilder()
-                                .addExecutionInterceptor(awsSdkTelemetry.newExecutionInterceptor())
+                                .addExecutionInterceptor(awsSdkTelemetry.createExecutionInterceptor())
                                 .build());
 
                 return wrapAsyncClientBuilder(builder, awsSdkTelemetry);


### PR DESCRIPTION
Quarkus 3.35 will update to <opentelemetry-instrumentation.version>2.25.0-alpha</opentelemetry-instrumentation.version>

* Fix compilation breaking changes
* Add support to wrap bedrock runtime async client