### PR TITLE
docs: fix floci image name for dev services

### DIFF
--- a/docs/modules/ROOT/pages/dev-services.adoc
+++ b/docs/modules/ROOT/pages/dev-services.adoc
@@ -61,7 +61,7 @@ Dev Services for Amazon Services uses different default images depending on the 
 * **LocalStack**: `localstack/localstack:4.13` (latest community version)
 * **MiniStack**: `ministackorg/ministack:latest` (not a fixed version as MiniStack is still in early development)
 * **Moto**: `motoserver/moto:latest` (latest version)
-* **Floci**: `hectorvent/floci:latest` (latest version)
+* **Floci**: `floci/floci:latest` (latest version)
 
 You can configure the image and version using the stack-specific properties:
 


### PR DESCRIPTION
Goal : Fix the old floci image name still used in docs making my coding agent using the wrong one.