### PR TITLE
Add separate RAG artifact for documentation search

### DIFF
--- a/common/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/common/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.amazonservices
+artifactId=quarkus-amazon-services-docs-rag

--- a/docs-rag/pom.xml
+++ b/docs-rag/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.amazonservices</groupId>
+        <artifactId>quarkus-amazon-services-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-amazon-services-docs-rag</artifactId>
+    <name>Quarkus Amazon Services - Documentation RAG</name>
+    <description>RAG vector embeddings for Quarkus Amazon Services documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <version>0.0.5</version>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <module>quarkus-messaging-amazon-sqs</module>
     <module>services</module>
     <module>integration-tests</module>
+    <module>docs-rag</module>
   </modules>
   <scm>
     <connection>:git:git@github.com:quarkiverse/quarkus-amazon-services.git</connection>


### PR DESCRIPTION
Ships RAG vector embeddings in a dedicated `docs-rag` module so AI assistants (quarkus-agent-mcp, chappie) can search all 52 documentation pages (371 chunks, 808K artifact).

- New `docs-rag` module runs the RAG plugin against all documentation pages (activated by `-Prag` or `-Prelease`)
- Pointer file `META-INF/quarkus-rag-artifact.properties` in common/deployment tells the loader where to find it
- No deployment JAR size impact (only gains a small pointer file)

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.