### PR TITLE
Netty - Add support for Quarkus 4

### DIFF
--- a/common/deployment-netty-client-internal/src/main/java/io/quarkiverse/amazon/common/deployment/netty/NettyTransportBuilderProcessor.java
+++ b/common/deployment-netty-client-internal/src/main/java/io/quarkiverse/amazon/common/deployment/netty/NettyTransportBuilderProcessor.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.Version;
 import io.quarkiverse.amazon.common.deployment.AmazonClientAsyncTransportBuildItem;
 import io.quarkiverse.amazon.common.deployment.AmazonClientExtensionBuildItem;
 import io.quarkiverse.amazon.common.deployment.RequireAmazonClientTransportBuilderBuildItem;
@@ -28,6 +29,7 @@ public class NettyTransportBuilderProcessor {
             BuildProducer<AmazonClientAsyncTransportBuildItem> asyncTransports,
             EventLoopGroupBuildItem eventLoopSupplier) {
 
+        boolean netty42 = isNetty42();
         extensions.forEach(extension -> createNettyAsyncTransportBuilder(
                 extension.getConfigName(),
                 amazonClients,
@@ -35,7 +37,23 @@ public class NettyTransportBuilderProcessor {
                 extension.getBuildAsyncConfig(),
                 extension.getAsyncConfig(),
                 asyncTransports,
-                eventLoopSupplier.getMainEventLoopGroup()));
+                eventLoopSupplier.getMainEventLoopGroup(),
+                netty42));
+    }
+
+    /**
+     * Checks whether Netty 4.2 is on the classpath.
+     * This is mainly for Quarkus 4 (which is using Netty 4.2). With this version of Netty, the AWS SDK cannot reuse
+     * the Quarkus event loop group (incompatible).
+     *
+     * @return {@code true} if Netty 4.2 is on the classpath
+     */
+    private boolean isNetty42() {
+        Version version = Version.identify().get("netty-buffer");
+        if (version == null) {
+            return false;
+        }
+        return version.artifactVersion().startsWith("4.2");
     }
 
     void createNettyAsyncTransportBuilder(String configName, List<RequireAmazonClientTransportBuilderBuildItem> amazonClients,
@@ -43,7 +61,8 @@ public class NettyTransportBuilderProcessor {
             AsyncHttpClientBuildTimeConfig buildAsyncConfig,
             RuntimeValue<AsyncHttpClientConfig> asyncConfig,
             BuildProducer<AmazonClientAsyncTransportBuildItem> clientAsyncTransports,
-            Supplier<EventLoopGroup> eventLoopSupplier) {
+            Supplier<EventLoopGroup> eventLoopSupplier,
+            boolean isNetty42) {
 
         Optional<RequireAmazonClientTransportBuilderBuildItem> matchingClientBuildItem = amazonClients.stream()
                 .filter(c -> c.getAwsClientName().equals(configName))
@@ -61,8 +80,11 @@ public class NettyTransportBuilderProcessor {
                     new AmazonClientAsyncTransportBuildItem(
                             client.getAwsClientName(),
                             client.getAsyncClassName().get(),
-                            recorder.configureNettyAsync(recorder.configureAsync(configName, asyncConfig), eventLoopSupplier,
-                                    asyncConfig)));
+                            recorder.configureNettyAsync(recorder.configureAsync(configName, asyncConfig),
+                                    configName,
+                                    eventLoopSupplier,
+                                    asyncConfig,
+                                    isNetty42)));
         });
     }
 

--- a/common/runtime-netty-client-internal/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
+++ b/common/runtime-netty-client-internal/src/main/java/io/quarkiverse/amazon/common/runtime/AmazonClientNettyTransportRecorder.java
@@ -2,7 +2,10 @@ package io.quarkiverse.amazon.common.runtime;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslProvider;
@@ -17,6 +20,8 @@ import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @Recorder
 public class AmazonClientNettyTransportRecorder extends AbstractAmazonClientTransportRecorder {
+
+    private static final Logger log = Logger.getLogger(AmazonClientNettyTransportRecorder.class);
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -69,11 +74,18 @@ public class AmazonClientNettyTransportRecorder extends AbstractAmazonClientTran
     }
 
     public RuntimeValue<SdkAsyncHttpClient.Builder> configureNettyAsync(RuntimeValue<SdkAsyncHttpClient.Builder> builderRuntime,
-            Supplier<EventLoopGroup> eventLoopSupplier, RuntimeValue<AsyncHttpClientConfig> asyncConfigRuntime) {
+            String configName,
+            Supplier<EventLoopGroup> eventLoopSupplier, RuntimeValue<AsyncHttpClientConfig> asyncConfigRuntime,
+            boolean isNetty42) {
         AsyncHttpClientConfig asyncConfig = asyncConfigRuntime.getValue();
         NettyNioAsyncHttpClient.Builder builder = (NettyNioAsyncHttpClient.Builder) builderRuntime.getValue();
-
-        if (asyncConfig.eventLoop().override()) {
+        Optional<Boolean> override = asyncConfig.eventLoop().override();
+        if (override.orElse(false) || isNetty42) {
+            if (override.isPresent() && !override.get()) {
+                log.warnf(
+                        "The AWS SDK Client cannot reuse the Quarkus Netty Event Loops when using Quarkus 4/Netty 4.2 - Ignoring `quarkus.%s.async-client.event-loop.override`",
+                        configName);
+            }
             SdkEventLoopGroup.Builder eventLoopBuilder = SdkEventLoopGroup.builder();
             asyncConfig.eventLoop().numberOfThreads().ifPresent(eventLoopBuilder::numberOfThreads);
             if (asyncConfig.eventLoop().threadNamePrefix().isPresent()) {
@@ -110,7 +122,7 @@ public class AmazonClientNettyTransportRecorder extends AbstractAmazonClientTran
                     String.format("quarkus.%s.async-client.max-pending-connection-acquires may not be negative or zero.",
                             extension));
         }
-        if (config.eventLoop().override()) {
+        if (config.eventLoop().override().orElse(false)) {
             if (config.eventLoop().numberOfThreads().isPresent() && config.eventLoop().numberOfThreads().getAsInt() <= 0) {
                 throw new RuntimeConfigurationError(
                         String.format("quarkus.%s.async-client.event-loop.number-of-threads may not be negative or zero.",

--- a/common/runtime-spi/src/main/java/io/quarkiverse/amazon/common/runtime/AsyncHttpClientConfig.java
+++ b/common/runtime-spi/src/main/java/io/quarkiverse/amazon/common/runtime/AsyncHttpClientConfig.java
@@ -193,9 +193,10 @@ public interface AsyncHttpClientConfig {
 
         /**
          * Enable the custom configuration of the Netty event loop group.
+         * This option is only available when using Quarkus 3.x.
+         * With Quarkus 4, the AWS SDK always uses its own event loop.
          */
-        @WithDefault("false")
-        boolean override();
+        Optional<Boolean> override();
 
         /**
          * Number of threads to use for the event loop group.


### PR DESCRIPTION
The SDK has an option to reuse the event loop group from Quarkus. However, in Quarkus 4, we switched to Netty 4.2 and our new event loops are not compatible with the one used in the SDK. So, when Netty 4.2 is detected on the classpath (at build time), this option is disabled.

This change is compatible with both Quarkus 3 and Quarkus 4.