### PR TITLE
#2226 Fix missing HTTP scheme in endpoint URL for reused DevServices containers

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/devservices/AbstractDevServicesAwsStackProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/devservices/AbstractDevServicesAwsStackProcessor.java
@@ -126,11 +126,6 @@ public abstract class AbstractDevServicesAwsStackProcessor {
      * returns a bare {@code host:port} string, which {@link java.net.URI#create(String)}
      * misinterprets — treating the host as the URI scheme.
      * <p>
-     * This mirrors the approach used in
-     * {@link LegacyDevServicesLocalStackProcessor} (which explicitly prepends
-     * {@code "http://"} when constructing the endpoint for reused containers)
-     * and in {@link MotoContainer#getEndpoint()} (which builds the URL with
-     * an {@code "http://"} prefix).
      *
      * @param endpoint the endpoint string, possibly without a scheme
      * @return the endpoint with an {@code http://} scheme, or unchanged if

--- a/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/devservices/AbstractDevServicesAwsStackProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/amazon/common/deployment/devservices/AbstractDevServicesAwsStackProcessor.java
@@ -99,8 +99,9 @@ public abstract class AbstractDevServicesAwsStackProcessor {
                         launchMode.getLaunchMode(), useSharedNetwork))
                 .map(containerAddress -> {
                     // Found existing container - reuse it
-                    reuseStackContainer(containerAddress.getUrl(), config, requestedServices);
-                    Map<String, String> discoveredConfig = buildDiscoveredConfig(containerAddress.getUrl(), requestedServices);
+                    var endpoint = ensureScheme(containerAddress.getUrl());
+                    reuseStackContainer(endpoint, config, requestedServices);
+                    Map<String, String> discoveredConfig = buildDiscoveredConfig(endpoint, requestedServices);
                     return DevServicesResultBuildItem.discovered()
                             .feature(getFeatureName())
                             .containerId(containerAddress.getId())
@@ -117,6 +118,32 @@ public abstract class AbstractDevServicesAwsStackProcessor {
                             .postStartHook(s -> logStartedAndPrepareStackContainer(s, requestedServices))
                             .build();
                 });
+    }
+
+    /**
+     * Prepends {@code http://} to an endpoint string if it does not already
+     * have a scheme. {@link io.quarkus.devservices.common.ContainerAddress#getUrl()}
+     * returns a bare {@code host:port} string, which {@link java.net.URI#create(String)}
+     * misinterprets — treating the host as the URI scheme.
+     * <p>
+     * This mirrors the approach used in
+     * {@link LegacyDevServicesLocalStackProcessor} (which explicitly prepends
+     * {@code "http://"} when constructing the endpoint for reused containers)
+     * and in {@link MotoContainer#getEndpoint()} (which builds the URL with
+     * an {@code "http://"} prefix).
+     *
+     * @param endpoint the endpoint string, possibly without a scheme
+     * @return the endpoint with an {@code http://} scheme, or unchanged if
+     *         it already has one, or {@code null} if the input is {@code null}
+     */
+    static String ensureScheme(String endpoint) {
+        if (endpoint == null) {
+            return null;
+        }
+        if (endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
+            return endpoint;
+        }
+        return "http://" + endpoint;
     }
 
     private void logStartedAndPrepareStackContainer(Startable s,

--- a/common/deployment/src/test/java/io/quarkiverse/amazon/common/deployment/devservices/EndpointSchemeNormalizationTest.java
+++ b/common/deployment/src/test/java/io/quarkiverse/amazon/common/deployment/devservices/EndpointSchemeNormalizationTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.amazon.common.deployment.devservices;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that {@link AbstractDevServicesAwsStackProcessor#ensureScheme(String)}
+ * normalizes endpoint strings so that {@code URI.create()} produces valid URIs
+ * with the correct scheme, host, and port.
+ */
+class EndpointSchemeNormalizationTest {
+
+    static Stream<Arguments> endpointProvider() {
+        return Stream.of(
+                Arguments.of("http://localhost:4566", "http", "localhost", 4566),
+                Arguments.of("https://localhost:4566", "https", "localhost", 4566),
+                Arguments.of("localhost:40456", "http", "localhost", 40456));
+    }
+
+    @ParameterizedTest
+    @MethodSource("endpointProvider")
+    void ensureSchemeProducesValidUri(String input, String expectedScheme, String expectedHost, int expectedPort) {
+        var result = AbstractDevServicesAwsStackProcessor.ensureScheme(input);
+        var uri = URI.create(result);
+        assertEquals(expectedScheme, uri.getScheme());
+        assertEquals(expectedHost, uri.getHost());
+        assertEquals(expectedPort, uri.getPort());
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertNull(AbstractDevServicesAwsStackProcessor.ensureScheme(null));
+    }
+}


### PR DESCRIPTION
Fix missing HTTP scheme in endpoint URL for reused DevServices containers

Fixes #2226